### PR TITLE
SLING-10452 adjust HTTP status code for invalid :redirect value for modifyAce/deleteAce post request

### DIFF
--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
@@ -80,6 +80,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
  * servlets
  */
 public abstract class AccessManagerClientTestSupport extends AccessManagerTestSupport {
+    protected static final int SC_UNPROCESSABLE_ENTITY = 422; // http status code for 422 Unprocessable Entity
+
     protected static final String TEST_FOLDER_JSON = "{'jcr:primaryType': 'nt:unstructured'}";
 
     protected static final String CONTENT_TYPE_JSON = "application/json";

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
@@ -1399,4 +1399,35 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
         assertEquals(testUserId, change.getString("argument"));
     }
 
+    private void testModifyAceRedirect(String redirectTo, int expectedStatus) throws IOException {
+        testUserId = createTestUser();
+
+        testFolderUrl = createTestFolder();
+
+        String postUrl = testFolderUrl + ".modifyAce.html";
+
+        List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair("principalId", testUserId));
+        postParams.add(new BasicNameValuePair("privilege@jcr:read", "granted"));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+
+        Credentials creds = new UsernamePasswordCredentials("admin", "admin");
+        assertAuthenticatedPostStatus(creds, postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testModifyAceValidRedirect() throws IOException, JsonException {
+        testModifyAceRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testModifyAceInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testModifyAceRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testModifyAceInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testModifyAceRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemoveAcesIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemoveAcesIT.java
@@ -312,5 +312,32 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
         assertEquals(testUserId, change.getString("argument"));
     }
 
+    private void testRemoveAceRedirect(String redirectTo, int expectedStatus) throws IOException {
+        String folderUrl = createFolderWithAces(false);
+
+        //remove the ace for the testUser principal
+        String postUrl = folderUrl + ".deleteAce.html";
+        List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair(":applyTo", testUserId));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+        Credentials creds = new UsernamePasswordCredentials("admin", "admin");
+        assertAuthenticatedPostStatus(creds, postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testRemoveAceValidRedirect() throws IOException, JsonException {
+        testRemoveAceRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testRemoveAceInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testRemoveAceRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testRemoveAceInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testRemoveAceRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
 }
 


### PR DESCRIPTION
When the modifyAce/deleteAce servlets receive an illegal or invalid :redirect parameter it should return a status code of 422 instead of 200 because the request was not fully successful.

Currently, the illegal :redirect parameter value is detected and a warning is logged.  The request continues to be processed without the redirect occurring.  The client has no indication that something went wrong without reviewing the server logs.

For example:

Illegal redirect 

curl -F principalId=myuser -F privilege@jcr:read=granted -F :redirect=https://sling.apache.org http://localhost:8080/test/node.modifyAce.html

invalid redirect

curl -F principalId=myuser -F privilege@jcr:read=granted -F :redirect=https:// http://localhost:8080/test/node.modifyAce.html