### PR TITLE
SLING-11233 Improve ACL json output for restrictions

### DIFF
--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/AddRemoveCallback.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/AddRemoveCallback.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.accessmanager.impl;
+
+/**
+ * Implement this interface to provide a callback handler
+ * for {@link SetWithAddRemoveCallbacks}
+ */
+public interface AddRemoveCallback<E> {
+
+    /**
+     * Callback invoked after an item is added to the set
+     * 
+     * @param item the item that was added
+     */
+    void added(E item);
+
+    /**
+     * Callback invoked after an item is removed from the set
+     * @param item the item that was removed
+     */
+    void removed(E item);
+
+}

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
@@ -77,6 +77,11 @@ public abstract class PrivilegesHelper {
     public static void mergePrivilegeSets(Privilege privilege,
             Map<Privilege, Set<Privilege>> privilegeToAncestorMap,
             Set<Privilege> add, Set<Privilege> remove) {
+        mergePrivilegeSets(privilege, privilegeToAncestorMap, add, remove, true);
+    }
+    public static void mergePrivilegeSets(Privilege privilege,
+            Map<Privilege, Set<Privilege>> privilegeToAncestorMap,
+            Set<Privilege> add, Set<Privilege> remove, boolean sameAllowAndDenyRestrictions) {
         //1. remove duplicates and invalid privileges from the list
         if (privilege.isAggregate()) {
             Privilege[] aggregatePrivileges = privilege.getAggregatePrivileges();
@@ -97,7 +102,9 @@ public abstract class PrivilegesHelper {
             //remove from the denied set
             remove.removeAll(asList);
         }
-        remove.remove(privilege);
+        if (sameAllowAndDenyRestrictions) {
+            remove.remove(privilege);
+        }
 
         //2. check if the privilege is already contained in another granted privilege
         boolean isAlreadyGranted = false;
@@ -105,6 +112,7 @@ public abstract class PrivilegesHelper {
         if (ancestorSet != null) {
             for (Privilege privilege2 : ancestorSet) {
                 if (add.contains(privilege2)) {
+                    add.remove(privilege);
                     isAlreadyGranted = true;
                     break;
                 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacks.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacks.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.accessmanager.impl;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Wrap another set with callbacks whenever any item
+ * is added or removed from the set.
+ */
+public class SetWithAddRemoveCallbacks<E> implements Set<E> {
+    private Set<E> wrapped;
+    private AddRemoveCallback<E> addRemoveCallback;
+    private Class<E> itemsClass;
+
+    public SetWithAddRemoveCallbacks(@NotNull Set<E> wrapped,
+            @NotNull AddRemoveCallback<E> addRemoveCallback,
+            @NotNull Class<E> itemsClass) {
+        this.wrapped = wrapped;
+        this.addRemoveCallback = addRemoveCallback;
+        this.itemsClass = itemsClass;
+    }
+
+    @Override
+    public int size() {
+        return wrapped.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return wrapped.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return wrapped.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return wrapped.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return wrapped.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return wrapped.toArray(a);
+    }
+
+    @Override
+    public boolean add(E e) {
+        boolean add = wrapped.add(e);
+        if (add) {
+            addRemoveCallback.added(e);
+        }
+        return add;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        boolean remove = wrapped.remove(o);
+        if (remove && itemsClass.isInstance(o)) {
+            addRemoveCallback.removed(itemsClass.cast(o));
+        }
+        return remove;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return wrapped.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        boolean modified = false;
+        if (c != null) {
+            for (E e : c) {
+                modified |= add(e);
+            }
+        }
+        return modified;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        Set<E> copy = new HashSet<>(this);
+        boolean retainAll = wrapped.retainAll(c);
+        //remove the ones that were retained
+        copy.removeAll(this);
+        //callback for ones that were not retained
+        for (E e : copy) {
+            addRemoveCallback.removed(e);
+        }
+        return retainAll;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        boolean modified = false;
+        if (c != null) {
+            for (Object e : c) {
+                modified |= remove(e);
+            }
+        }
+        return modified;
+    }
+
+    @Override
+    public void clear() {
+        Set<E> copy = new HashSet<>(this);
+        wrapped.clear();
+        for (E e : copy) {
+            addRemoveCallback.removed(e);
+        }
+    }
+
+}

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacks.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacks.java
@@ -81,9 +81,12 @@ public class SetWithAddRemoveCallbacks<E> implements Set<E> {
 
     @Override
     public boolean remove(Object o) {
-        boolean remove = wrapped.remove(o);
-        if (remove && itemsClass.isInstance(o)) {
-            addRemoveCallback.removed(itemsClass.cast(o));
+        boolean remove = false;
+        if (itemsClass.isInstance(o)) {
+            remove = wrapped.remove(o);
+            if (remove) {
+                addRemoveCallback.removed(itemsClass.cast(o));
+            }
         }
         return remove;
     }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
@@ -65,9 +65,15 @@ public abstract class AbstractGetAclServlet extends SlingAllMethodsServlet {
     protected static final String KEY_PRIVILEGES = "privileges";
     protected static final String KEY_ALLOW = "allow";
     protected static final String KEY_DENY = "deny";
-    @Deprecated // since 3.0.12
+    /**
+     * @deprecated since 3.0.12, To be removed before the exported package version goes to 4.0
+     */
+    @Deprecated
     protected static final String KEY_DENIED = "denied";
-    @Deprecated // since 3.0.12
+    /**
+     * @deprecated since 3.0.12, To be removed before the exported package version goes to 4.0
+     */
+    @Deprecated
     protected static final String KEY_GRANTED = "granted";
 
     private transient RestrictionProvider restrictionProvider;

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
@@ -17,23 +17,24 @@
 package org.apache.sling.jcr.jackrabbit.accessmanager.post;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Item;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
-import javax.jcr.ValueFormatException;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.Privilege;
 import javax.json.Json;
@@ -45,19 +46,43 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ResourceNotFoundException;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
+import org.apache.sling.jcr.jackrabbit.accessmanager.impl.AddRemoveCallback;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrivilegesHelper;
+import org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("serial")
 public abstract class AbstractGetAclServlet extends SlingAllMethodsServlet {
 
+    protected static final String KEY_PRINCIPAL = "principal";
     protected static final String KEY_ORDER = "order";
+    protected static final String KEY_PRIVILEGES = "privileges";
+    protected static final String KEY_ALLOW = "allow";
+    protected static final String KEY_DENY = "deny";
+    @Deprecated // since 3.0.12
     protected static final String KEY_DENIED = "denied";
+    @Deprecated // since 3.0.12
     protected static final String KEY_GRANTED = "granted";
+
+    private transient RestrictionProvider restrictionProvider;
+
+    // @Reference
+    protected void bindRestrictionProvider(RestrictionProvider rp) {
+        this.restrictionProvider = rp;
+    }
+
+    /**
+     * Return the RestrictionProvider service
+     */
+    protected RestrictionProvider getRestrictionProvider() {
+        return restrictionProvider;
+    }
 
     /* (non-Javadoc)
      * @see org.apache.sling.api.servlets.SlingSafeMethodsServlet#doGet(org.apache.sling.api.SlingHttpServletRequest, org.apache.sling.api.SlingHttpServletResponse)
@@ -73,7 +98,7 @@ public abstract class AbstractGetAclServlet extends SlingAllMethodsServlet {
 
             JsonObject acl = internalGetAcl(session, resourcePath);
             response.setContentType("application/json");
-            response.setCharacterEncoding("UTF-8");
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
             boolean isTidy = false;
             final String[] selectors = request.getRequestPathInfo().getSelectors();
@@ -102,7 +127,6 @@ public abstract class AbstractGetAclServlet extends SlingAllMethodsServlet {
         }
     }
 
-    @SuppressWarnings("unchecked")
     protected JsonObject internalGetAcl(Session jcrSession, String resourcePath) throws RepositoryException {
 
         if (jcrSession == null) {
@@ -116,157 +140,171 @@ public abstract class AbstractGetAclServlet extends SlingAllMethodsServlet {
             throw new ResourceNotFoundException("Resource is not a JCR Node");
         }
 
+        //make a temp map for quick lookup below
+        Set<RestrictionDefinition> supportedRestrictions = getRestrictionProvider().getSupportedRestrictions(resourcePath);
+        Map<String, RestrictionDefinition> srMap = new HashMap<>();
+        for (RestrictionDefinition restrictionDefinition : supportedRestrictions) {
+            srMap.put(restrictionDefinition.getName(), restrictionDefinition);
+        }
+
         // Calculate a map of privileges to all the aggregate privileges it is contained in.
         // Use for fast lookup during the mergePrivilegeSets calls below.
         Map<Privilege, Set<Privilege>> privilegeToAncestorMap = PrivilegesHelper.buildPrivilegeToAncestorMap(jcrSession, resourcePath);
 
-        AccessControlEntry[] declaredAccessControlEntries = getAccessControlEntries(jcrSession, resourcePath);
-        Map<String, Map<String, Object>> aclMap = new LinkedHashMap<>();
-        Map<String, Map<String, Object>> restrictionMap = new LinkedHashMap<>();
-        int sequence = 0;
-
-        for (AccessControlEntry ace : declaredAccessControlEntries) {
-            Principal principal = ace.getPrincipal();
-            Map<String, Object> map = aclMap.get(principal.getName());
-            if (map == null) {
-                map = new LinkedHashMap<>();
-                aclMap.put(principal.getName(), map);
-                map.put(KEY_ORDER, sequence++);
-            }
-        }
-        //evaluate these in reverse order so the most entries with highest specificity are last
-        for (int i = declaredAccessControlEntries.length - 1; i >= 0; i--) {
-            AccessControlEntry ace = declaredAccessControlEntries[i];
-            Principal principal = ace.getPrincipal();
-
-            if (ace instanceof JackrabbitAccessControlEntry) {
-                JackrabbitAccessControlEntry jace = (JackrabbitAccessControlEntry)ace;
-                String[] restrictionNames = jace.getRestrictionNames();
-                if (restrictionNames != null) {
-                    Map<String, Object> restrictions = restrictionMap.get(principal.getName());
-                    if (restrictions == null) {
-                        restrictions = new HashMap<>();
-                        restrictionMap.put(principal.getName(), restrictions);
-                    }
-                    for (String rname : restrictionNames) {
-                        try {
-                            //try as a single-value restriction
-                            Value value = jace.getRestriction(rname);
-                            restrictions.put(rname, value);
-                        } catch (ValueFormatException vfe) {
-                            //try as a multi-value restriction
-                            Value[] values = jace.getRestrictions(rname);
-                            restrictions.put(rname, values);
-                        }
-                    }
-                }
-            }
-
-            Map<String, Object> map = aclMap.get(principal.getName());
-
-            Set<Privilege> grantedSet = (Set<Privilege>) map.get(KEY_GRANTED);
-            if (grantedSet == null) {
-                grantedSet = new LinkedHashSet<>();
-                map.put(KEY_GRANTED, grantedSet);
-            }
-            Set<Privilege> deniedSet = (Set<Privilege>) map.get(KEY_DENIED);
-            if (deniedSet == null) {
-                deniedSet = new LinkedHashSet<>();
-                map.put(KEY_DENIED, deniedSet);
-            }
-
-            boolean allow = AccessControlUtil.isAllow(ace);
-            if (allow) {
-                Privilege[] privileges = ace.getPrivileges();
-                for (Privilege privilege : privileges) {
-                    PrivilegesHelper.mergePrivilegeSets(privilege,
-                            privilegeToAncestorMap,
-                            grantedSet, deniedSet);
-                }
-            } else {
-                Privilege[] privileges = ace.getPrivileges();
-                for (Privilege privilege : privileges) {
-                    PrivilegesHelper.mergePrivilegeSets(privilege,
-                            privilegeToAncestorMap,
-                            deniedSet, grantedSet);
-                }
-            }
-        }
-
-        List<JsonObject> aclList = new ArrayList<>();
-        Set<Entry<String, Map<String, Object>>> entrySet = aclMap.entrySet();
-        for (Entry<String, Map<String, Object>> entry : entrySet) {
-            String principalName = entry.getKey();
-            Map<String, Object> value = entry.getValue();
-
-            JsonObjectBuilder aceObject = Json.createObjectBuilder();
-            aceObject.add("principal", principalName);
-
-            Set<Privilege> grantedSet = (Set<Privilege>) value.get(KEY_GRANTED);
-            if (grantedSet != null && !grantedSet.isEmpty()) {
-                JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
-                for (Privilege v : grantedSet)
-                {
-                    arrayBuilder.add(v.getName());
-                }
-                aceObject.add(KEY_GRANTED, arrayBuilder);
-            }
-
-            Set<Privilege> deniedSet = (Set<Privilege>) value.get(KEY_DENIED);
-            if (deniedSet != null && !deniedSet.isEmpty()) {
-                JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
-                for (Privilege v : deniedSet)
-                {
-                    arrayBuilder.add(v.getName());
-                }
-                aceObject.add(KEY_DENIED, arrayBuilder);
-            }
-            aceObject.add(KEY_ORDER, (Integer) value.get(KEY_ORDER));
-
-            Map<String, Object> restrictions = restrictionMap.get(principalName);
-            if (restrictions != null && !restrictions.isEmpty()) {
-                Set<Entry<String, Object>> entrySet2 = restrictions.entrySet();
-                JsonObjectBuilder jsonRestrictions = Json.createObjectBuilder();
-                for (Entry<String, Object> entry2 : entrySet2) {
-                    Object rvalue = entry2.getValue();
-                    if (rvalue != null) {
-                        if (rvalue.getClass().isArray()) {
-                            JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
-                            int length = Array.getLength(rvalue);
-                            for (int i= 0; i  < length; i++) {
-                                Object object = Array.get(rvalue, i);
-                                addTo(arrayBuilder, object);
-                            }
-                            jsonRestrictions.add(entry2.getKey(), arrayBuilder);
+        AccessControlEntry[] accessControlEntries = getAccessControlEntries(jcrSession, resourcePath);
+        Map<Principal, Integer> principalToOrderMap = new HashMap<>();
+        Map<Principal, Map<Privilege, LocalPrivilege>> principalToPrivilegesMap = new HashMap<>();
+        //evaluate these in reverse order so the entries with highest specificity are processed last
+        for (int i = accessControlEntries.length - 1; i >= 0; i--) {
+            AccessControlEntry accessControlEntry = accessControlEntries[i];
+            if (accessControlEntry instanceof JackrabbitAccessControlEntry) {
+                JackrabbitAccessControlEntry jrAccessControlEntry = (JackrabbitAccessControlEntry)accessControlEntry;
+                Privilege[] privileges = jrAccessControlEntry.getPrivileges();
+                if (privileges != null) {
+                    boolean isAllow = jrAccessControlEntry.isAllow();
+                    Principal principal = accessControlEntry.getPrincipal();
+                    principalToOrderMap.put(principal, i);
+                    Map<Privilege, LocalPrivilege> map = principalToPrivilegesMap.computeIfAbsent(principal, k -> new HashMap<>());
+                    for (Privilege p : privileges) {
+                        LocalPrivilege privilegeItem = map.computeIfAbsent(p, LocalPrivilege::new);
+                        if (isAllow) {
+                            privilegeItem.setAllow(true);
                         } else {
-                            addTo(jsonRestrictions, entry2.getKey(), rvalue);
+                            privilegeItem.setDeny(true);
+                        }
+
+                        // populate the declared restrictions
+                        @NotNull
+                        String[] restrictionNames = jrAccessControlEntry.getRestrictionNames();
+                        Set<LocalRestriction> restrictionItems = new HashSet<>();
+                        for (String restrictionName : restrictionNames) {
+                            RestrictionDefinition rd = srMap.get(restrictionName);
+                            boolean isMulti = rd.getRequiredType().isArray();
+                            if (isMulti) {
+                                restrictionItems.add(new LocalRestriction(rd, jrAccessControlEntry.getRestrictions(restrictionName)));
+                            } else {
+                                restrictionItems.add(new LocalRestriction(rd, jrAccessControlEntry.getRestriction(restrictionName)));
+                            }
+                        }
+                        if (isAllow) {
+                            privilegeItem.setAllowRestrictions(restrictionItems);
+                        } else {
+                            privilegeItem.setDenyRestrictions(restrictionItems);
                         }
                     }
+
+                    mergePrivilegeSets(privilegeToAncestorMap, privileges, isAllow, map);
                 }
-                aceObject.add("restrictions", jsonRestrictions);
             }
-            
-            aclList.add(aceObject.build());
-        }
-        JsonObjectBuilder jsonAclMap = Json.createObjectBuilder();
-        for (Map.Entry<String, Map<String, Object>> entry : aclMap.entrySet())
-        {
-            JsonObjectBuilder builder = Json.createObjectBuilder();
-            for (Map.Entry<String, Object> inner : entry.getValue().entrySet())
-            {
-                addTo(builder, inner.getKey(), inner.getValue());
-            }
-            jsonAclMap.add(entry.getKey(), builder);
         }
 
-        for (JsonObject jsonObj : aclList) {
-            jsonAclMap.add(jsonObj.getString("principal"), jsonObj);
-        }
+        // sort the entries by the order value for readability
+        List<Entry<Principal, Map<Privilege, LocalPrivilege>>> entrySetList = new ArrayList<>(principalToPrivilegesMap.entrySet());
+        Collections.sort(entrySetList, (e1, e2) -> principalToOrderMap.get(e1.getKey()).compareTo(principalToOrderMap.get(e2.getKey())));
 
-        return jsonAclMap.build();
+        // convert the data to JSON
+        JsonObjectBuilder jsonObj = convertToJson(entrySetList);
+        return jsonObj.build();
     }
-    
-    private JsonObjectBuilder addTo(JsonObjectBuilder builder, String key, Object value) {
+
+    protected void mergePrivilegeSets(Map<Privilege, Set<Privilege>> privilegeToAncestorMap, Privilege[] privileges,
+            boolean isAllow, Map<Privilege, LocalPrivilege> map) {
+        // prepare a filtered set that contains only the allow privileges
+        Set<Privilege> allowSet =
+                map.entrySet().stream()
+                    .filter(e -> e.getValue().isAllow())
+                    .map(Entry::getKey)
+                    .collect(Collectors.toSet());
+        // prepare a filtered set that contains only the deny privileges
+        Set<Privilege> denySet =
+                map.entrySet().stream()
+                    .filter(e -> e.getValue().isDeny())
+                    .map(Entry::getKey)
+                    .collect(Collectors.toSet());
+
+        for (Privilege privilege : privileges) {
+            // filter the allowSet/denySet to only include the
+            //   items with identical restrictions
+            LocalPrivilege lp = map.get(privilege);
+            allowSet = new SetWithAddRemoveCallbacks<>(
+                    allowSet.stream()
+                        .filter(p -> lp.sameAllowRestrictions(map.get(p)))
+                        .collect(Collectors.toSet()),
+                        new AddRemoveAllowPrivilegeCallback(map),
+                    Privilege.class);
+            denySet = new SetWithAddRemoveCallbacks<>(
+                    denySet.stream()
+                    .filter(p -> lp.sameDenyRestrictions(map.get(p)))
+                    .collect(Collectors.toSet()),
+                    new AddRemoveDenyPrivilegeCallback(map),
+                    Privilege.class);
+
+            // to tell the mergePrivilegeSets calls if the allow and deny restrictions 
+            //  are the same so it can know if allow/deny are exclusive
+            boolean sameAllowAndDenyRestrictions = lp.sameAllowAndDenyRestrictions();
+            if (isAllow) {
+                PrivilegesHelper.mergePrivilegeSets(privilege,
+                        privilegeToAncestorMap,
+                        allowSet, denySet, sameAllowAndDenyRestrictions);
+            } else {
+                PrivilegesHelper.mergePrivilegeSets(privilege,
+                        privilegeToAncestorMap,
+                        denySet, allowSet, sameAllowAndDenyRestrictions);
+            }
+        }
+    }
+
+    protected JsonObjectBuilder convertToJson(List<Entry<Principal, Map<Privilege, LocalPrivilege>>> entrySetList) {
+        JsonObjectBuilder jsonObj = Json.createObjectBuilder();
+        for (int i = 0; i < entrySetList.size(); i++) {
+            Entry<Principal, Map<Privilege, LocalPrivilege>> entry = entrySetList.get(i);
+            Principal principal = entry.getKey();
+            JsonObjectBuilder principalObj = Json.createObjectBuilder();
+            principalObj.add(KEY_PRINCIPAL, principal.getName());
+            principalObj.add(KEY_ORDER, i);
+            JsonObjectBuilder privilegesObj = Json.createObjectBuilder();
+            Collection<LocalPrivilege> privileges = entry.getValue().values();
+            for (LocalPrivilege pi : privileges) {
+                if (pi.isNone()) {
+                    continue;
+                }
+                JsonObjectBuilder privilegeObj = Json.createObjectBuilder();
+
+                if (pi.isAllow()) {
+                    addRestrictions(privilegeObj, KEY_ALLOW, pi.getAllowRestrictions());
+                }
+                if (pi.isDeny()) {
+                    addRestrictions(privilegeObj, KEY_DENY, pi.getDenyRestrictions());
+                }
+                privilegesObj.add(pi.getName(), privilegeObj);
+            }
+            principalObj.add(KEY_PRIVILEGES, privilegesObj);
+            jsonObj.add(principal.getName(), principalObj);
+        }
+        return jsonObj;
+    }
+
+    protected void addRestrictions(JsonObjectBuilder privilegeObj, String key, Set<LocalRestriction> restrictions) {
+        if (restrictions.isEmpty()) {
+            privilegeObj.add(key, true);
+        } else {
+            JsonObjectBuilder allowObj = Json.createObjectBuilder();
+            for (LocalRestriction ri : restrictions) {
+                if (ri.isMultiValue()) {
+                    JsonArrayBuilder rvalues = Json.createArrayBuilder();
+                    for (Value value: ri.getValues()) {
+                        addTo(rvalues, value);
+                    }
+                    allowObj.add(ri.getName(), rvalues);
+                } else {
+                    addTo(allowObj, ri.getName(), ri.getValue());
+                }
+            }
+            privilegeObj.add(key, allowObj);
+        }
+    }
+
+    protected JsonObjectBuilder addTo(JsonObjectBuilder builder, String key, Object value) {
         if (value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long) {
             builder.add(key, ((Number) value).longValue());
         } else if (value instanceof Float || value instanceof Double) {
@@ -283,7 +321,7 @@ public abstract class AbstractGetAclServlet extends SlingAllMethodsServlet {
         return builder;
     }
 
-    private JsonArrayBuilder addTo(JsonArrayBuilder builder, Object value) {
+    protected JsonArrayBuilder addTo(JsonArrayBuilder builder, Object value) {
         if (value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long) {
             builder.add(((Number) value).longValue());
         } else if (value instanceof Float || value instanceof Double) {
@@ -297,5 +335,65 @@ public abstract class AbstractGetAclServlet extends SlingAllMethodsServlet {
     }
 
     protected abstract AccessControlEntry[] getAccessControlEntries(Session session, String absPath) throws RepositoryException;
+
+    /**
+     * callback to do additional updates to the principalToPrivilegesMap when
+     * calls to PrivilegesHelper.mergePrivilegeSets(..) makes changes to the privilege sets 
+     */
+    private static final class AddRemoveDenyPrivilegeCallback implements AddRemoveCallback<Privilege> {
+        private final Map<Privilege, LocalPrivilege> map;
+
+        private AddRemoveDenyPrivilegeCallback(Map<Privilege, LocalPrivilege> map) {
+            this.map = map;
+        }
+
+        @Override
+        public void added(Privilege p) {
+            LocalPrivilege newItem = map.computeIfAbsent(p, LocalPrivilege::new);
+            newItem.setDeny(true);
+        }
+
+        @Override
+        public void removed(Privilege p) {
+            LocalPrivilege lp = map.get(p);
+            if (lp != null) {
+                lp.setDeny(false);
+                if (lp.isNone()) {
+                    // not granted or denied, so we can purge the entry
+                    map.remove(p);
+                }
+            }
+        }
+    }
+
+    /**
+     * callback to do additional updates to the principalToPrivilegesMap when
+     * calls to PrivilegesHelper.mergePrivilegeSets(..) makes changes to the privilege sets 
+     */
+    private static final class AddRemoveAllowPrivilegeCallback implements AddRemoveCallback<Privilege> {
+        private final Map<Privilege, LocalPrivilege> map;
+
+        private AddRemoveAllowPrivilegeCallback(Map<Privilege, LocalPrivilege> map) {
+            this.map = map;
+        }
+
+        @Override
+        public void added(Privilege p) {
+            LocalPrivilege newItem = map.computeIfAbsent(p, LocalPrivilege::new);
+            newItem.setAllow(true);
+        }
+
+        @Override
+        public void removed(Privilege p) {
+            LocalPrivilege lp = map.get(p);
+            if (lp != null) {
+                lp.setAllow(false);
+                if (lp.isNone()) {
+                    // not granted or denied, so we can purge the entry
+                    map.remove(p);
+                }
+            }
+        }
+    }
 
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAclServlet.java
@@ -29,9 +29,11 @@ import javax.jcr.security.AccessControlPolicy;
 import javax.json.JsonObject;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetAcl;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * <p>
@@ -60,40 +62,36 @@ import org.osgi.service.component.annotations.Component;
  * <h4>Example Response</h4>
  * <code style='white-space: pre'>
  * {
- * &quot;principalNameA&quot;:
- *      { &quot;granted&quot; : [
- *           &quot;permission1&quot;,
- *           &quot;permission2&quot;,
- *           &quot;permission3&quot;,
- *           &quot;permission4&quot; ],
- *        &quot;denied&quot; : [
- *           &quot;permission5&quot;,
- *           &quot;permission6&quot;,
- *           &quot;permission7&quot;,
- *           &quot;permission8&quot;]
- *       },
- * &quot;principalNameB&quot;:
- *       { &quot;granted&quot; : [
- *           &quot;permission1&quot;,
- *           &quot;permission2&quot;,
- *           &quot;permission3&quot;,
- *           &quot;permission4&quot; ],
- *         &quot;denied&quot; : [
- *           &quot;permission5&quot;,
- *           &quot;permission6&quot;,
- *           &quot;permission7&quot;,
- *           &quot;permission8&quot;] },
- * &quot;principalNameC&quot;:
- *       { &quot;granted&quot; : [
- *           &quot;permission1&quot;,
- *           &quot;permission2&quot;,
- *           &quot;permission3&quot;,
- *           &quot;permission4&quot; ],
- *         &quot;denied&quot; : [
- *           &quot;permission5&quot;,
- *           &quot;permission6&quot;,
- *           &quot;permission7&quot;,
- *           &quot;permission8&quot;] }
+ * &quot;principalNameA&quot;:{ 
+ *    &quot;permissions&quot;: {
+ *      &quot;permission1&quot;:{
+ *           &quot;allow&quot;:true
+ *      },
+ *      &quot;permission2&quot;:{
+ *           &quot;allow&quot;:true
+ *      },
+ *      &quot;permission5&quot;:{
+ *           &quot;deny&quot;:true
+ *      }
+ *    },
+ * &quot;principalNameB&quot;:{ 
+ *    &quot;permissions&quot;: {
+ *      &quot;permission1&quot;:{
+ *           &quot;allow&quot;:true
+ *      },
+ *      &quot;permission2&quot;:{
+ *           &quot;allow&quot;:[
+ *              "restrictionName1: "restrictionValue1",
+ *              "restrictionName2: [
+ *                  "restrictionValue2a",
+ *                  "restrictionValue2b"
+ *              ]
+ *           ]
+ *      },
+ *      &quot;permission5&quot;:{
+ *           &quot;deny&quot;:true
+ *      }
+ *    }
  * }
  * </code>
  */
@@ -106,7 +104,13 @@ property= {
         "sling.servlet.selectors=tidy.acl",
         "sling.servlet.extensions=json",
         "sling.servlet.prefix:Integer=-1"
-})
+},
+reference = {
+        @Reference(name="RestrictionProvider",
+                bind = "bindRestrictionProvider",
+                service = RestrictionProvider.class)
+}
+)
 public class GetAclServlet extends AbstractGetAclServlet implements GetAcl {
     private static final long serialVersionUID = 3391376559396223185L;
 

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAclServlet.java
@@ -29,9 +29,11 @@ import javax.jcr.security.AccessControlPolicy;
 import javax.json.JsonObject;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetEffectiveAcl;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * <p>
@@ -60,40 +62,36 @@ import org.osgi.service.component.annotations.Component;
  * <h4>Example Response</h4>
  * <code style='white-space: pre'>
  * {
- * &quot;principalNameA&quot;:
- *      { &quot;granted&quot; : [
- *           &quot;permission1&quot;,
- *           &quot;permission2&quot;,
- *           &quot;permission3&quot;,
- *           &quot;permission4&quot; ],
- *        &quot;denied&quot; : [
- *           &quot;permission5&quot;,
- *           &quot;permission6&quot;,
- *           &quot;permission7&quot;,
- *           &quot;permission8&quot;]
- *       },
- * &quot;principalNameB&quot;:
- *       { &quot;granted&quot; : [
- *           &quot;permission1&quot;,
- *           &quot;permission2&quot;,
- *           &quot;permission3&quot;,
- *           &quot;permission4&quot; ],
- *         &quot;denied&quot; : [
- *           &quot;permission5&quot;,
- *           &quot;permission6&quot;,
- *           &quot;permission7&quot;,
- *           &quot;permission8&quot;] },
- * &quot;principalNameC&quot;:
- *       { &quot;granted&quot; : [
- *           &quot;permission1&quot;,
- *           &quot;permission2&quot;,
- *           &quot;permission3&quot;,
- *           &quot;permission4&quot; ],
- *         &quot;denied&quot; : [
- *           &quot;permission5&quot;,
- *           &quot;permission6&quot;,
- *           &quot;permission7&quot;,
- *           &quot;permission8&quot;] }
+ * &quot;principalNameA&quot;:{ 
+ *    &quot;permissions&quot;: {
+ *      &quot;permission1&quot;:{
+ *           &quot;allow&quot;:true
+ *      },
+ *      &quot;permission2&quot;:{
+ *           &quot;allow&quot;:true
+ *      },
+ *      &quot;permission5&quot;:{
+ *           &quot;deny&quot;:true
+ *      }
+ *    },
+ * &quot;principalNameB&quot;:{ 
+ *    &quot;permissions&quot;: {
+ *      &quot;permission1&quot;:{
+ *           &quot;allow&quot;:true
+ *      },
+ *      &quot;permission2&quot;:{
+ *           &quot;allow&quot;:[
+ *              "restrictionName1: "restrictionValue1",
+ *              "restrictionName2: [
+ *                  "restrictionValue2a",
+ *                  "restrictionValue2b"
+ *              ]
+ *           ]
+ *      },
+ *      &quot;permission5&quot;:{
+ *           &quot;deny&quot;:true
+ *      }
+ *    }
  * }
  * </code>
  */
@@ -106,7 +104,13 @@ property= {
         "sling.servlet.selectors=tidy.eacl",
         "sling.servlet.extensions=json",
         "sling.servlet.prefix:Integer=-1"
-})
+},
+reference = {
+        @Reference(name="RestrictionProvider",
+                bind = "bindRestrictionProvider",
+                service = RestrictionProvider.class)
+}
+)
 @SuppressWarnings("serial")
 public class GetEffectiveAclServlet extends AbstractGetAclServlet implements GetEffectiveAcl {
 

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilege.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilege.java
@@ -189,6 +189,8 @@ public class LocalPrivilege {
         if (privilege == null) {
             if (other.privilege != null)
                 return false;
+        } else if (other.privilege == null) {
+            return false;
         } else if (!privilege.getName().equals(other.privilege.getName()))
             return false;
         return true;

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilege.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilege.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.accessmanager.post;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.jcr.security.Privilege;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Use to holds details of a privilege
+ */
+public class LocalPrivilege {
+    private Privilege privilege;
+    private boolean allow;
+    private boolean deny;
+    private Set<LocalRestriction> allowRestrictions = Collections.emptySet();
+    private Set<LocalRestriction> denyRestrictions = Collections.emptySet();
+
+    public LocalPrivilege(@NotNull Privilege privilege) {
+        this.privilege = privilege;
+    }
+
+    public Privilege getPrivilege() {
+        return privilege;
+    }
+
+    public String getName() {
+        return privilege.getName();
+    }
+
+    public boolean isNone() {
+        return !allow && !deny;
+    }
+
+    public boolean isAllow() {
+        return allow;
+    }
+
+    public boolean isDeny() {
+        return deny;
+    }
+
+    public void setAllow(boolean allow) {
+        this.allow = allow;
+    }
+
+    public void setDeny(boolean deny) {
+        this.deny = deny;
+    }
+
+    public Set<LocalRestriction> getAllowRestrictions() {
+        return allowRestrictions;
+    }
+
+    public Set<LocalRestriction> getDenyRestrictions() {
+        return denyRestrictions;
+    }
+
+    public void setAllowRestrictions(Set<LocalRestriction> restrictions) {
+        this.allowRestrictions = restrictions;
+    }
+    public void setDenyRestrictions(Set<LocalRestriction> restrictions) {
+        this.denyRestrictions = restrictions;
+    }
+
+    /**
+     * compares if restrictions present is same as specified restrictions in the
+     * supplied argument
+     * 
+     * @param lp the other LocalPrivilege to compare to
+     * @return true or false
+     */
+    public boolean sameAllowRestrictions(LocalPrivilege lp) {
+        boolean same = false;
+        Set<LocalRestriction> otherAllowRestrictions = lp.getAllowRestrictions();
+        // total (multivalue and simple)  number of restrictions should be same
+        if (allowRestrictions.size() == otherAllowRestrictions.size() &&
+                allowRestrictions.containsAll(otherAllowRestrictions)) {
+            // allow and deny list seems to be the same
+            same = true;
+        }
+        return same;
+    }
+
+    /**
+     * compares if restrictions present is same as specified restrictions in the
+     * supplied argument
+     * 
+     * @param lp the other LocalPrivilege to compare to
+     * @return true or false
+     */
+    public boolean sameDenyRestrictions(LocalPrivilege lp) {
+        boolean same = false;
+        Set<LocalRestriction> otherDenyRestrictions = lp.getDenyRestrictions();
+        // total (multivalue and simple)  number of restrictions should be same
+        if (denyRestrictions.size() == otherDenyRestrictions.size() &&
+                denyRestrictions.containsAll(otherDenyRestrictions)) {
+            // allow and deny list seems to be the same
+            same = true;
+        }
+        return same;
+    }
+
+    /**
+     * compares if allow and deny restrictions are the same
+     * 
+     * @return true or false
+     */
+    public boolean sameAllowAndDenyRestrictions() {
+        boolean same = false;
+        // total (multivalue and simple)  number of restrictions should be same
+        if (allowRestrictions.size() == denyRestrictions.size() &&
+                allowRestrictions.containsAll(denyRestrictions)) {
+            // allow and deny list seems to be the same
+            same = true;
+        }
+        return same;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("LocalPrivilege [name=");
+        builder.append(getName());
+        builder.append(", allow=");
+        builder.append(allow);
+        builder.append(", deny=");
+        builder.append(deny);
+        builder.append(", allowRestrictions=");
+        builder.append(allowRestrictions);
+        builder.append(", denyRestrictions=");
+        builder.append(denyRestrictions);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (allow ? 1231 : 1237);
+        result = prime * result + ((allowRestrictions == null) ? 0 : allowRestrictions.hashCode());
+        result = prime * result + (deny ? 1231 : 1237);
+        result = prime * result + ((denyRestrictions == null) ? 0 : denyRestrictions.hashCode());
+        result = prime * result + ((privilege == null) ? 0 : privilege.getName().hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        LocalPrivilege other = (LocalPrivilege) obj;
+        if (allow != other.allow)
+            return false;
+        if (allowRestrictions == null) {
+            if (other.allowRestrictions != null)
+                return false;
+        } else if (!allowRestrictions.equals(other.allowRestrictions))
+            return false;
+        if (deny != other.deny)
+            return false;
+        if (denyRestrictions == null) {
+            if (other.denyRestrictions != null)
+                return false;
+        } else if (!denyRestrictions.equals(other.denyRestrictions))
+            return false;
+        if (privilege == null) {
+            if (other.privilege != null)
+                return false;
+        } else if (!privilege.getName().equals(other.privilege.getName()))
+            return false;
+        return true;
+    }
+
+}

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestriction.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestriction.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.accessmanager.post;
+
+import java.util.Arrays;
+
+import javax.jcr.Value;
+
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Use to holds details of a restriction
+ */
+public class LocalRestriction {
+
+    private RestrictionDefinition rd;
+    private Value[] values;
+
+    public LocalRestriction(@NotNull RestrictionDefinition rd, @Nullable Value value) {
+        super();
+        this.rd = rd;
+        this.values = value == null ? null : new Value[] { value };
+    }
+    public LocalRestriction(@NotNull RestrictionDefinition rd, @Nullable Value[] values) {
+        super();
+        this.rd = rd;
+        this.values = values;
+    }
+
+    public String getName() {
+        return rd.getName();
+    }
+
+    public boolean isMultiValue() {
+        return rd.getRequiredType().isArray();
+    }
+
+    public Value getValue() {
+        Value v = null;
+        if (values != null && values.length > 0) {
+            v = values[0];
+        }
+        return v;
+    }
+
+    public Value[] getValues() {
+        return values;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("LocalRestriction [name=");
+        builder.append(rd.getName());
+        builder.append(", value=");
+        builder.append(getValues());
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((rd == null) ? 0 : rd.getName().hashCode());
+        result = prime * result + Arrays.hashCode(values);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        LocalRestriction other = (LocalRestriction) obj;
+        if (rd == null) {
+            if (other.rd != null)
+                return false;
+        } else if (!rd.getName().equals(other.rd.getName()))
+            return false;
+        if (!Arrays.equals(values, other.values))
+            return false;
+        return true;
+    }
+
+}

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestriction.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestriction.java
@@ -97,9 +97,7 @@ public class LocalRestriction {
                 return false;
         } else if (!rd.getName().equals(other.rd.getName()))
             return false;
-        if (!Arrays.equals(values, other.values))
-            return false;
-        return true;
+        return Arrays.equals(values, other.values);
     }
 
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestriction.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestriction.java
@@ -67,7 +67,7 @@ public class LocalRestriction {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("LocalRestriction [name=");
-        builder.append(rd.getName());
+        builder.append(rd == null ? null : rd.getName());
         builder.append(", value=");
         builder.append(getValues());
         builder.append("]");
@@ -95,6 +95,8 @@ public class LocalRestriction {
         if (rd == null) {
             if (other.rd != null)
                 return false;
+        } else if (other.rd == null) {
+            return false;
         } else if (!rd.getName().equals(other.rd.getName()))
             return false;
         return Arrays.equals(values, other.values);

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/package-info.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("3.4.0")
+@org.osgi.annotation.versioning.Version("3.5.0")
 package org.apache.sling.jcr.jackrabbit.accessmanager.post;
 
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacksTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacksTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.accessmanager.impl;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link SetWithAddRemoveCallbacks}
+ *
+ */
+public class SetWithAddRemoveCallbacksTest {
+
+    private static final class TestAddRemoveCallback implements AddRemoveCallback<String> {
+        private List<String> addedItems = new ArrayList<>();
+        private List<String> removedItems = new ArrayList<>();
+
+        @Override
+        public void added(String item) {
+            addedItems.add(item);
+        }
+
+        @Override
+        public void removed(String item) {
+            removedItems.add(item);
+        }
+
+        public void reset() {
+            addedItems.clear();
+            removedItems.clear();
+        };
+    }
+
+    private TestAddRemoveCallback addRemoveCallback = new TestAddRemoveCallback();
+
+    SetWithAddRemoveCallbacks<String> wrap(Set<String> set) {
+        return new SetWithAddRemoveCallbacks<>(set, 
+                addRemoveCallback, String.class);
+    }
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#size()}.
+     */
+    @Test
+    public void testSize() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+        assertEquals(set1.size(), setWithCallbacks1.size());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#isEmpty()}.
+     */
+    @Test
+    public void testIsEmpty() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        assertTrue(setWithCallbacks1.isEmpty());
+
+        set1.add("hello");
+        assertFalse(setWithCallbacks1.isEmpty());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#contains(java.lang.Object)}.
+     */
+    @Test
+    public void testContains() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        assertFalse(setWithCallbacks1.contains("hello"));
+
+        set1.add("hello");
+        assertTrue(setWithCallbacks1.contains("hello"));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#iterator()}.
+     */
+    @Test
+    public void testIterator() {
+        Set<String> set1 = new HashSet<>();
+        set1.add("hello");
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+        Iterator<String> iterator = setWithCallbacks1.iterator();
+        assertNotNull(iterator);
+        assertEquals("hello", iterator.next());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#toArray()}.
+     */
+    @Test
+    public void testToArray() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        assertArrayEquals(new String[0], setWithCallbacks1.toArray());
+
+        set1.add("hello");
+        assertArrayEquals(new String[] { "hello" }, setWithCallbacks1.toArray());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#toArray(T[])}.
+     */
+    @Test
+    public void testToArrayTArray() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        assertArrayEquals(new String[0], setWithCallbacks1.toArray());
+
+        set1.add("hello");
+        assertArrayEquals(new String[] { "hello" }, setWithCallbacks1.toArray(new String[1]));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#add(java.lang.Object)}.
+     */
+    @Test
+    public void testAdd() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.addedItems.size());
+        setWithCallbacks1.add("item1");
+        assertEquals(1, addRemoveCallback.addedItems.size());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#remove(java.lang.Object)}.
+     */
+    @Test
+    public void testRemove() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        set1.add("hello");
+        set1.add("hello2");
+
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.removedItems.size());
+        setWithCallbacks1.remove("hello");
+        assertEquals(1, addRemoveCallback.removedItems.size());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#containsAll(java.util.Collection)}.
+     */
+    @Test
+    public void testContainsAll() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        set1.add("hello");
+        set1.add("hello2");
+        assertTrue(setWithCallbacks1.containsAll(new HashSet<>(set1)));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#addAll(java.util.Collection)}.
+     */
+    @Test
+    public void testAddAll() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.addedItems.size());
+        setWithCallbacks1.addAll(new HashSet<>(Arrays.asList("item1", "item2")));
+        assertEquals(2, addRemoveCallback.addedItems.size());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#retainAll(java.util.Collection)}.
+     */
+    @Test
+    public void testRetainAll() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        set1.add("hello");
+        set1.add("hello2");
+        assertFalse(setWithCallbacks1.isEmpty());
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.removedItems.size());
+        setWithCallbacks1.retainAll(new HashSet<>(set1));
+        assertEquals(0, addRemoveCallback.removedItems.size());
+
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.removedItems.size());
+        setWithCallbacks1.retainAll(new HashSet<>());
+        assertEquals(2, addRemoveCallback.removedItems.size());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#removeAll(java.util.Collection)}.
+     */
+    @Test
+    public void testRemoveAll() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        set1.add("hello");
+        set1.add("hello2");
+        assertFalse(setWithCallbacks1.isEmpty());
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.removedItems.size());
+        setWithCallbacks1.removeAll(new HashSet<>(set1));
+        assertEquals(2, addRemoveCallback.removedItems.size());
+        assertTrue(setWithCallbacks1.isEmpty());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#clear()}.
+     */
+    @Test
+    public void testClear() {
+        Set<String> set1 = new HashSet<>();
+        SetWithAddRemoveCallbacks<String> setWithCallbacks1 = wrap(set1);
+
+        set1.add("hello");
+        assertFalse(setWithCallbacks1.isEmpty());
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.removedItems.size());
+        setWithCallbacks1.clear();
+        assertEquals(1, addRemoveCallback.removedItems.size());
+        assertTrue(setWithCallbacks1.isEmpty());
+    }
+
+}

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacksTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/SetWithAddRemoveCallbacksTest.java
@@ -159,6 +159,7 @@ public class SetWithAddRemoveCallbacksTest {
     /**
      * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.impl.SetWithAddRemoveCallbacks#remove(java.lang.Object)}.
      */
+    @SuppressWarnings("unlikely-arg-type")
     @Test
     public void testRemove() {
         Set<String> set1 = new HashSet<>();
@@ -171,6 +172,11 @@ public class SetWithAddRemoveCallbacksTest {
         assertEquals(0, addRemoveCallback.removedItems.size());
         setWithCallbacks1.remove("hello");
         assertEquals(1, addRemoveCallback.removedItems.size());
+
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.removedItems.size());
+        setWithCallbacks1.remove(Boolean.TRUE);
+        assertEquals(0, addRemoveCallback.removedItems.size());
     }
 
     /**
@@ -198,6 +204,11 @@ public class SetWithAddRemoveCallbacksTest {
         assertEquals(0, addRemoveCallback.addedItems.size());
         setWithCallbacks1.addAll(new HashSet<>(Arrays.asList("item1", "item2")));
         assertEquals(2, addRemoveCallback.addedItems.size());
+
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.addedItems.size());
+        setWithCallbacks1.addAll(null);
+        assertEquals(0, addRemoveCallback.addedItems.size());
     }
 
     /**
@@ -238,6 +249,11 @@ public class SetWithAddRemoveCallbacksTest {
         setWithCallbacks1.removeAll(new HashSet<>(set1));
         assertEquals(2, addRemoveCallback.removedItems.size());
         assertTrue(setWithCallbacks1.isEmpty());
+
+        addRemoveCallback.reset();
+        assertEquals(0, addRemoveCallback.removedItems.size());
+        setWithCallbacks1.removeAll(null);
+        assertEquals(0, addRemoveCallback.removedItems.size());
     }
 
     /**

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAclIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAclIT.java
@@ -18,16 +18,12 @@ package org.apache.sling.jcr.jackrabbit.accessmanager.it;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-import javax.json.JsonArray;
 import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.servlet.http.HttpServletResponse;
@@ -98,17 +94,11 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        JsonArray grantedArray = aceObject.getJsonArray("granted");
-        assertNotNull(grantedArray);
-        assertEquals(1, grantedArray.size());
-        Set<String> grantedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < grantedArray.size(); i++) {
-            grantedPrivilegeNames.add(grantedArray.getString(i));
-        }
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_WRITE);
-
-        Object deniedArray = aceObject.get("denied");
-        assertNull(deniedArray);
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertEquals(1, privilegesObject.size());
+        //allow privilege
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_WRITE);
 
         JsonObject aceObject2 = jsonObject.getJsonObject(testUserId2);
         assertNotNull(aceObject2);
@@ -116,19 +106,12 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString2 = aceObject2.getString("principal");
         assertEquals(testUserId2, principalString2);
 
-        JsonArray grantedArray2 = aceObject2.getJsonArray("granted");
-        assertNotNull(grantedArray2);
-        assertEquals(2, grantedArray2.size());
-        Set<String> grantedPrivilegeNames2 = new HashSet<>();
-        for (int i=0; i < grantedArray2.size(); i++) {
-            grantedPrivilegeNames2.add(grantedArray2.getString(i));
-        }
-        assertPrivilege(grantedPrivilegeNames2, true, PrivilegeConstants.JCR_WRITE);
-        assertPrivilege(grantedPrivilegeNames2, true, PrivilegeConstants.JCR_LOCK_MANAGEMENT);
-
-        Object deniedArray2 = aceObject2.get("denied");
-        assertNull(deniedArray2);
-
+        JsonObject privilegesObject2 = aceObject2.getJsonObject("privileges");
+        assertNotNull(privilegesObject2);
+        assertEquals(2, privilegesObject2.size());
+        //allow privilege
+        assertPrivilege(privilegesObject2, true, true, PrivilegeConstants.JCR_WRITE);
+        assertPrivilege(privilegesObject2, true, true, PrivilegeConstants.JCR_LOCK_MANAGEMENT);
     }
 
     /**
@@ -174,17 +157,11 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        JsonArray grantedArray = aceObject.getJsonArray("granted");
-        assertNotNull(grantedArray);
-        assertEquals(1, grantedArray.size());
-        Set<String> grantedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < grantedArray.size(); i++) {
-            grantedPrivilegeNames.add(grantedArray.getString(i));
-        }
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_WRITE);
-
-        Object deniedArray = aceObject.get("denied");
-        assertNull(deniedArray);
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertEquals(1, privilegesObject.size());
+        //allow privilege
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_WRITE);
     }
 
     /**
@@ -230,17 +207,11 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        JsonArray grantedArray = aceObject.getJsonArray("granted");
-        assertNotNull(grantedArray);
-        assertEquals(1, grantedArray.size());
-        Set<String> grantedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < grantedArray.size(); i++) {
-            grantedPrivilegeNames.add(grantedArray.getString(i));
-        }
-        assertPrivilege(grantedPrivilegeNames, true, PrivilegeConstants.JCR_ALL);
-
-        Object deniedArray = aceObject.get("denied");
-        assertNull(deniedArray);
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertEquals(1, privilegesObject.size());
+        //allow privilege
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_ALL);
     }
 
     /**
@@ -286,17 +257,11 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        JsonArray grantedArray = aceObject.getJsonArray("granted");
-        assertNotNull(grantedArray);
-        assertEquals(1, grantedArray.size());
-        Set<String> grantedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < grantedArray.size(); i++) {
-            grantedPrivilegeNames.add(grantedArray.getString(i));
-        }
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_ALL);
-
-        Object deniedArray = aceObject.get("denied");
-        assertNull(deniedArray);
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertEquals(1, privilegesObject.size());
+        //allow privilege
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_ALL);
     }
 
     /**
@@ -342,35 +307,26 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        JsonArray grantedArray = aceObject.getJsonArray("granted");
-        assertNotNull(grantedArray);
-        assertTrue(grantedArray.size() >= 11);
-        Set<String> grantedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < grantedArray.size(); i++) {
-            grantedPrivilegeNames.add(grantedArray.getString(i));
-        }
-        assertPrivilege(grantedPrivilegeNames,false,PrivilegeConstants.JCR_ALL);
-        assertPrivilege(grantedPrivilegeNames,false,PrivilegeConstants.JCR_WRITE);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_READ);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_READ_ACCESS_CONTROL);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_MODIFY_ACCESS_CONTROL);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_LOCK_MANAGEMENT);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_VERSION_MANAGEMENT);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_NODE_TYPE_MANAGEMENT);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_RETENTION_MANAGEMENT);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_LIFECYCLE_MANAGEMENT);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_MODIFY_PROPERTIES);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_ADD_CHILD_NODES);
-        assertPrivilege(grantedPrivilegeNames,true,PrivilegeConstants.JCR_REMOVE_CHILD_NODES);
-
-        JsonArray deniedArray = aceObject.getJsonArray("denied");
-        assertNotNull(deniedArray);
-        assertEquals(1, deniedArray.size());
-        Set<String> deniedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < deniedArray.size(); i++) {
-            deniedPrivilegeNames.add(deniedArray.getString(i));
-        }
-        assertPrivilege(deniedPrivilegeNames, true, PrivilegeConstants.JCR_REMOVE_NODE);
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertTrue(privilegesObject.size() >= 11);
+        // not there privileges
+        assertPrivilege(privilegesObject, false, true, PrivilegeConstants.JCR_ALL);
+        assertPrivilege(privilegesObject, false, true, PrivilegeConstants.JCR_WRITE);
+        // allow privileges
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_READ);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_READ_ACCESS_CONTROL);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_MODIFY_ACCESS_CONTROL);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_LOCK_MANAGEMENT);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_VERSION_MANAGEMENT);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_NODE_TYPE_MANAGEMENT);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_RETENTION_MANAGEMENT);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_LIFECYCLE_MANAGEMENT);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_MODIFY_PROPERTIES);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_ADD_CHILD_NODES);
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_REMOVE_CHILD_NODES);
+        //deny privileges
+        assertPrivilege(privilegesObject, true, false, PrivilegeConstants.JCR_REMOVE_NODE);
     }
 
     /**
@@ -416,17 +372,10 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        Object grantedArray = aceObject.get("granted");
-        assertNull(grantedArray);
-
-        JsonArray deniedArray = aceObject.getJsonArray("denied");
-        assertNotNull(deniedArray);
-        assertEquals(1, deniedArray.size());
-        Set<String> deniedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < deniedArray.size(); i++) {
-            deniedPrivilegeNames.add(deniedArray.getString(i));
-        }
-        assertPrivilege(deniedPrivilegeNames, true, PrivilegeConstants.JCR_ALL);
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertEquals(1, privilegesObject.size());
+        assertPrivilege(privilegesObject, true, false, PrivilegeConstants.JCR_ALL);
     }
 
     /**
@@ -472,16 +421,9 @@ public class GetAclIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        Object grantedArray = aceObject.get("granted");
-        assertNull(grantedArray);
-
-        JsonArray deniedArray = aceObject.getJsonArray("denied");
-        assertNotNull(deniedArray);
-        assertEquals(1, deniedArray.size());
-        Set<String> deniedPrivilegeNames = new HashSet<>();
-        for (int i=0; i < deniedArray.size(); i++) {
-            deniedPrivilegeNames.add(deniedArray.getString(i));
-        }
-        assertPrivilege(deniedPrivilegeNames, true, PrivilegeConstants.JCR_ALL);
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertEquals(1, privilegesObject.size());
+        assertPrivilege(privilegesObject, true, false, PrivilegeConstants.JCR_ALL);
     }
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemoveAcesIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemoveAcesIT.java
@@ -35,6 +35,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.sling.servlets.post.JSONResponse;
 import org.apache.sling.servlets.post.PostResponseCreator;
 import org.junit.After;
@@ -125,13 +126,13 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
         String principalString = aceObject.getString("principal");
         assertEquals(testUserId, principalString);
 
-        JsonArray grantedArray = aceObject.getJsonArray("granted");
-        assertNotNull(grantedArray);
-        assertEquals("jcr:read", grantedArray.getString(0));
-
-        JsonArray deniedArray = aceObject.getJsonArray("denied");
-        assertNotNull(deniedArray);
-        assertEquals("jcr:write", deniedArray.getString(0));
+        JsonObject privilegesObject = aceObject.getJsonObject("privileges");
+        assertNotNull(privilegesObject);
+        assertEquals(2, privilegesObject.size());
+        //allow privileges
+        assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_READ);
+        //deny privileges
+        assertPrivilege(privilegesObject, true, false, PrivilegeConstants.JCR_WRITE);
 
         if (addGroupAce) {
             aceObject = jsonObject.getJsonObject(testGroupId);
@@ -140,11 +141,13 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
             principalString = aceObject.getString("principal");
             assertEquals(testGroupId, principalString);
 
-                assertEquals(1, aceObject.getInt("order"));
+            assertEquals(1, aceObject.getInt("order"));
 
-            grantedArray = aceObject.getJsonArray("granted");
-            assertNotNull(grantedArray);
-            assertEquals("jcr:read", grantedArray.getString(0));
+            privilegesObject = aceObject.getJsonObject("privileges");
+            assertNotNull(privilegesObject);
+            assertEquals(1, privilegesObject.size());
+            //allow privileges
+            assertPrivilege(privilegesObject, true, true, PrivilegeConstants.JCR_READ);
         }
 
         return testFolderUrl;

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
@@ -378,14 +378,16 @@ public class LocalPrivilegeTest {
         assertEquals(lp20, lp21);
 
         LocalPrivilege lp22 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp22.setAllowRestrictions(null);
         LocalPrivilege lp23 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         lp23.setAllowRestrictions(null);
-        assertNotEquals(lp22, lp23);
+        assertEquals(lp22, lp23);
 
         LocalPrivilege lp24 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp24.setDenyRestrictions(null);
         LocalPrivilege lp25 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         lp25.setDenyRestrictions(null);
-        assertNotEquals(lp24, lp25);
+        assertEquals(lp24, lp25);
     }
 
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.accessmanager.post;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.Privilege;
+
+import org.apache.jackrabbit.oak.security.authorization.restriction.RestrictionProviderImpl;
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
+import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
+import org.apache.jackrabbit.value.ValueFactoryImpl;
+import org.apache.sling.jcr.base.util.AccessControlUtil;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for {@link LocalPrivilege}
+ */
+public class LocalPrivilegeTest {
+
+    @Rule
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    private AccessControlManager acm;
+    private Map<String, RestrictionDefinition> srMap;
+
+    @Before
+    public void setup() throws RepositoryException {
+        Session session = context.resourceResolver().adaptTo(Session.class);
+        acm = AccessControlUtil.getAccessControlManager(session);
+        context.registerService(new RestrictionProviderImpl());
+    }
+
+    private Privilege priv(String privilegeName) throws RepositoryException {
+        return acm.privilegeFromName(privilegeName);
+    }
+
+    private RestrictionDefinition rd(String restrictionName) throws Exception {
+        if (srMap == null) {
+            //make a temp map for quick lookup below
+            RestrictionProvider restrictionProvider = context.getService(RestrictionProvider.class);
+            Set<RestrictionDefinition> supportedRestrictions = restrictionProvider.getSupportedRestrictions("/");
+            srMap = new HashMap<>();
+            for (RestrictionDefinition restrictionDefinition : supportedRestrictions) {
+                srMap.put(restrictionDefinition.getName(), restrictionDefinition);
+            }
+        }
+        return srMap.get(restrictionName);
+    }
+
+    private Value val(String value) {
+        return ValueFactoryImpl.getInstance().createValue(value);
+    }
+    private Value[] vals(String ... value) {
+        Value[] values = new Value[value.length];
+        ValueFactory vf = ValueFactoryImpl.getInstance();
+        for (int i = 0; i < value.length; i++) {
+            values[i] = vf.createValue(value[i]);
+        }
+        return values;
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#hashCode()}.
+     */
+    @Test
+    public void testHashCode() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        LocalPrivilege lp2 = new LocalPrivilege(priv(PrivilegeConstants.JCR_WRITE));
+        assertNotSame(lp1.hashCode(), lp2.hashCode());
+
+        LocalPrivilege lp3 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertEquals(lp1.hashCode(), lp3.hashCode());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#getPrivilege()}.
+     */
+    @Test
+    public void testGetPrivilege() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertEquals(priv(PrivilegeConstants.JCR_READ), lp1.getPrivilege());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#getName()}.
+     */
+    @Test
+    public void testGetName() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertEquals(PrivilegeConstants.JCR_READ, lp1.getName());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#isNone()}.
+     */
+    @Test
+    public void testIsNone() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertTrue(lp1.isNone());
+
+        // deny set, allow not set
+        lp1.setDeny(true);
+        assertFalse(lp1.isNone());
+
+        // allow set, deny set
+        lp1.setAllow(true);
+        assertFalse(lp1.isNone());
+
+        // deny not set, allow set
+        lp1.setDeny(false);
+        assertFalse(lp1.isNone());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#isAllow()}.
+     */
+    @Test
+    public void testIsAllow() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertFalse(lp1.isAllow());
+
+        lp1.setAllow(true);
+        assertTrue(lp1.isAllow());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#isDeny()}.
+     */
+    @Test
+    public void testIsDeny() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertFalse(lp1.isDeny());
+
+        lp1.setDeny(true);
+        assertTrue(lp1.isDeny());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#getAllowRestrictions()}.
+     */
+    @Test
+    public void testGetAllowRestrictions() throws Exception {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        Set<LocalRestriction> allowRestrictions = lp1.getAllowRestrictions();
+        assertNotNull(allowRestrictions);
+        assertTrue(allowRestrictions.isEmpty());
+
+        Set<LocalRestriction> newAllowRestrictions = new HashSet<>();
+        newAllowRestrictions.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        lp1.setAllowRestrictions(newAllowRestrictions);
+        Set<LocalRestriction> allowRestrictions2 = lp1.getAllowRestrictions();
+        assertNotNull(allowRestrictions2);
+        assertFalse(allowRestrictions2.isEmpty());
+        assertEquals(newAllowRestrictions, allowRestrictions2);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#getDenyRestrictions()}.
+     */
+    @Test
+    public void testGetDenyRestrictions() throws Exception {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        Set<LocalRestriction> denyRestrictions = lp1.getDenyRestrictions();
+        assertNotNull(denyRestrictions);
+        assertTrue(denyRestrictions.isEmpty());
+
+        Set<LocalRestriction> newDenyRestrictions = new HashSet<>();
+        newDenyRestrictions.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        lp1.setDenyRestrictions(newDenyRestrictions);
+        Set<LocalRestriction> denyRestrictions2 = lp1.getDenyRestrictions();
+        assertNotNull(denyRestrictions2);
+        assertFalse(denyRestrictions2.isEmpty());
+        assertEquals(newDenyRestrictions, denyRestrictions2);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#sameAllowRestrictions(org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege)}.
+     */
+    @Test
+    public void testSameAllowRestrictions() throws Exception {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        LocalPrivilege lp2 = new LocalPrivilege(priv(PrivilegeConstants.JCR_WRITE));
+        assertTrue(lp1.sameAllowRestrictions(lp2));
+
+        Set<LocalRestriction> newAllowRestrictions1 = new HashSet<>();
+        newAllowRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newAllowRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        lp1.setAllowRestrictions(newAllowRestrictions1);
+        assertFalse(lp1.sameAllowRestrictions(lp2));
+
+        Set<LocalRestriction> newAllowRestrictions2 = new HashSet<>();
+        newAllowRestrictions2.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newAllowRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        lp2.setAllowRestrictions(newAllowRestrictions2);
+        assertTrue(lp1.sameAllowRestrictions(lp2));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#sameDenyRestrictions(org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege)}.
+     */
+    @Test
+    public void testSameDenyRestrictions() throws Exception {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        LocalPrivilege lp2 = new LocalPrivilege(priv(PrivilegeConstants.JCR_WRITE));
+        assertTrue(lp1.sameDenyRestrictions(lp2));
+
+        Set<LocalRestriction> newDenyRestrictions1 = new HashSet<>();
+        newDenyRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newDenyRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        lp1.setDenyRestrictions(newDenyRestrictions1);
+        assertFalse(lp1.sameDenyRestrictions(lp2));
+
+        Set<LocalRestriction> newDenyRestrictions2 = new HashSet<>();
+        newDenyRestrictions2.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newDenyRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        lp2.setDenyRestrictions(newDenyRestrictions2);
+        assertTrue(lp1.sameDenyRestrictions(lp2));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#sameAllowAndDenyRestrictions()}.
+     */
+    @Test
+    public void testSameAllowAndDenyRestrictions() throws Exception {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertTrue(lp1.sameAllowAndDenyRestrictions());
+
+        Set<LocalRestriction> newDenyRestrictions1 = new HashSet<>();
+        newDenyRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newDenyRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        lp1.setDenyRestrictions(newDenyRestrictions1);
+        assertFalse(lp1.sameAllowAndDenyRestrictions());
+
+        Set<LocalRestriction> newAllowRestrictions1 = new HashSet<>();
+        newAllowRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newAllowRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        lp1.setAllowRestrictions(newAllowRestrictions1);
+        assertTrue(lp1.sameAllowAndDenyRestrictions());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#toString()}.
+     */
+    @Test
+    public void testToString() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertNotNull(lp1.toString());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#equals(java.lang.Object)}.
+     */
+    @Test
+    public void testEqualsObject() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertEquals(lp1, lp1);
+        assertNotEquals(lp1, null);
+        assertNotEquals(lp1, this);
+
+        LocalPrivilege lp2 = new LocalPrivilege(priv(PrivilegeConstants.JCR_WRITE));
+        assertNotEquals(lp1, lp2);
+
+        LocalPrivilege lp3 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertEquals(lp1, lp3);
+    }
+
+}

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
@@ -20,9 +20,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -101,10 +101,23 @@ public class LocalPrivilegeTest {
     public void testHashCode() throws RepositoryException {
         LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         LocalPrivilege lp2 = new LocalPrivilege(priv(PrivilegeConstants.JCR_WRITE));
-        assertNotSame(lp1.hashCode(), lp2.hashCode());
+        assertNotEquals(lp1.hashCode(), lp2.hashCode());
 
         LocalPrivilege lp3 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         assertEquals(lp1.hashCode(), lp3.hashCode());
+
+        LocalPrivilege lp4 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp4.setAllow(true);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+        lp4.setDeny(true);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+        lp4.setAllowRestrictions(null);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+        lp4.setDenyRestrictions(null);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+
+        LocalPrivilege lp5 = new LocalPrivilege(null);
+        assertNotEquals(lp1.hashCode(), lp5.hashCode());
     }
 
     /**
@@ -228,6 +241,12 @@ public class LocalPrivilegeTest {
         newAllowRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
         lp2.setAllowRestrictions(newAllowRestrictions2);
         assertTrue(lp1.sameAllowRestrictions(lp2));
+
+        Set<LocalRestriction> newAllowRestrictions3 = new HashSet<>();
+        newAllowRestrictions3.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newAllowRestrictions3.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2_changed")));
+        lp2.setAllowRestrictions(newAllowRestrictions3);
+        assertFalse(lp1.sameAllowRestrictions(lp2));
     }
 
     /**
@@ -250,6 +269,12 @@ public class LocalPrivilegeTest {
         newDenyRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
         lp2.setDenyRestrictions(newDenyRestrictions2);
         assertTrue(lp1.sameDenyRestrictions(lp2));
+
+        Set<LocalRestriction> newDenyRestrictions3 = new HashSet<>();
+        newDenyRestrictions3.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newDenyRestrictions3.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2_changed")));
+        lp2.setDenyRestrictions(newDenyRestrictions3);
+        assertFalse(lp1.sameDenyRestrictions(lp2));
     }
 
     /**
@@ -271,6 +296,12 @@ public class LocalPrivilegeTest {
         newAllowRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
         lp1.setAllowRestrictions(newAllowRestrictions1);
         assertTrue(lp1.sameAllowAndDenyRestrictions());
+
+        Set<LocalRestriction> newAllowRestrictions2 = new HashSet<>();
+        newAllowRestrictions2.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newAllowRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2_changed")));
+        lp1.setAllowRestrictions(newAllowRestrictions2);
+        assertFalse(lp1.sameAllowAndDenyRestrictions());
     }
 
     /**
@@ -286,7 +317,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalPrivilege#equals(java.lang.Object)}.
      */
     @Test
-    public void testEqualsObject() throws RepositoryException {
+    public void testEqualsObject() throws Exception {
         LocalPrivilege lp1 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         assertEquals(lp1, lp1);
         assertNotEquals(lp1, null);
@@ -297,6 +328,54 @@ public class LocalPrivilegeTest {
 
         LocalPrivilege lp3 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         assertEquals(lp1, lp3);
+
+        LocalPrivilege lp4 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp4.setAllow(true);
+        assertNotEquals(lp1, lp4);
+
+        LocalPrivilege lp5 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp5.setDeny(true);
+        assertNotEquals(lp1, lp5);
+
+        LocalPrivilege lp6 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp6.setAllowRestrictions(null);
+        assertNotEquals(lp1, lp6);
+
+        LocalPrivilege lp7 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp7.setDenyRestrictions(null);
+        assertNotEquals(lp1, lp7);
+
+        LocalPrivilege lp8 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp8.setAllowRestrictions(null);
+        LocalPrivilege lp9 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertNotEquals(lp8, lp9);
+
+        LocalPrivilege lp10 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp10.setDenyRestrictions(null);
+        LocalPrivilege lp11 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertNotEquals(lp10, lp11);
+
+        LocalPrivilege lp12 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp12.setAllowRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(rd("rep:glob"), val("/hello")))));
+        LocalPrivilege lp13 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertNotEquals(lp12, lp13);
+
+        LocalPrivilege lp14 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp14.setDenyRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(rd("rep:glob"), val("/hello")))));
+        LocalPrivilege lp15 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertNotEquals(lp14, lp15);
+
+        LocalPrivilege lp16 = new LocalPrivilege(null);
+        LocalPrivilege lp17 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        assertNotEquals(lp16, lp17);
+
+        LocalPrivilege lp18 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        LocalPrivilege lp19 = new LocalPrivilege(null);
+        assertNotEquals(lp18, lp19);
+
+        LocalPrivilege lp20 = new LocalPrivilege(null);
+        LocalPrivilege lp21 = new LocalPrivilege(null);
+        assertEquals(lp20, lp21);
     }
 
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
@@ -376,6 +376,16 @@ public class LocalPrivilegeTest {
         LocalPrivilege lp20 = new LocalPrivilege(null);
         LocalPrivilege lp21 = new LocalPrivilege(null);
         assertEquals(lp20, lp21);
+
+        LocalPrivilege lp22 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        LocalPrivilege lp23 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp23.setAllowRestrictions(null);
+        assertNotEquals(lp22, lp23);
+
+        LocalPrivilege lp24 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        LocalPrivilege lp25 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
+        lp25.setDenyRestrictions(null);
+        assertNotEquals(lp24, lp25);
     }
 
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
@@ -135,8 +135,14 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testGetValues() throws Exception {
-        LocalRestriction lr2 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
-        assertArrayEquals(vals("item1", "item2"), lr2.getValues());
+        LocalRestriction lr1 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
+        assertArrayEquals(vals("item1", "item2"), lr1.getValues());
+
+        LocalRestriction lr2 = new LocalRestriction(rd("rep:itemNames"), (Value[])null);
+        assertNull(lr2.getValues());
+
+        LocalRestriction lr3 = new LocalRestriction(rd("rep:itemNames"), new Value[0]);
+        assertArrayEquals(new Value[0], lr3.getValues());
     }
 
     /**
@@ -163,6 +169,26 @@ public class LocalRestrictionTest {
 
         LocalRestriction lr3 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
         assertEquals(lr1, lr3);
+
+        LocalRestriction lr4 = new LocalRestriction(null, val("/hello1"));
+        LocalRestriction lr5 = new LocalRestriction(null, val("/hello1"));
+        assertEquals(lr4, lr5);
+
+        LocalRestriction lr6 = new LocalRestriction(null, val("/hello1"));
+        LocalRestriction lr7 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertNotEquals(lr6, lr7);
+
+        LocalRestriction lr8 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr9 = new LocalRestriction(null, val("/hello1"));
+        assertNotEquals(lr8, lr9);
+
+        LocalRestriction lr10 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr11 = new LocalRestriction(rd("rep:itemNames"), val("/hello1"));
+        assertNotEquals(lr10, lr11);
+
+        LocalRestriction lr12 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr13 = new LocalRestriction(rd("rep:glob"), val("/hello2"));
+        assertNotEquals(lr12, lr13);
     }
 
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.accessmanager.post;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+
+import org.apache.jackrabbit.oak.security.authorization.restriction.RestrictionProviderImpl;
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
+import org.apache.jackrabbit.value.ValueFactoryImpl;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for {@link LocalRestriction}
+ *
+ */
+public class LocalRestrictionTest {
+
+    @Rule
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    private Map<String, RestrictionDefinition> srMap;
+
+    @Before
+    public void setup() throws RepositoryException {
+        context.registerService(new RestrictionProviderImpl());
+    }
+
+    private RestrictionDefinition rd(String restrictionName) throws Exception {
+        if (srMap == null) {
+            //make a temp map for quick lookup below
+            RestrictionProvider restrictionProvider = context.getService(RestrictionProvider.class);
+            Set<RestrictionDefinition> supportedRestrictions = restrictionProvider.getSupportedRestrictions("/");
+            srMap = new HashMap<>();
+            for (RestrictionDefinition restrictionDefinition : supportedRestrictions) {
+                srMap.put(restrictionDefinition.getName(), restrictionDefinition);
+            }
+        }
+        return srMap.get(restrictionName);
+    }
+
+    private Value val(String value) {
+        return ValueFactoryImpl.getInstance().createValue(value);
+    }
+    private Value[] vals(String ... value) {
+        Value[] values = new Value[value.length];
+        ValueFactory vf = ValueFactoryImpl.getInstance();
+        for (int i = 0; i < value.length; i++) {
+            values[i] = vf.createValue(value[i]);
+        }
+        return values;
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalRestriction#hashCode()}.
+     */
+    @Test
+    public void testHashCode() throws Exception {
+        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), val("/hello2"));
+        assertNotSame(lr1.hashCode(), lr2.hashCode());
+
+        LocalRestriction lr3 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertEquals(lr1.hashCode(), lr3.hashCode());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalRestriction#getName()}.
+     */
+    @Test
+    public void testGetName() throws Exception {
+        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertEquals("rep:glob", lr1.getName());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalRestriction#isMultiValue()}.
+     */
+    @Test
+    public void testIsMultiValue() throws Exception {
+        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertFalse(lr1.isMultiValue());
+
+        LocalRestriction lr2 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
+        assertTrue(lr2.isMultiValue());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalRestriction#getValue()}.
+     */
+    @Test
+    public void testGetValue() throws Exception {
+        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertEquals(val("/hello1"), lr1.getValue());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalRestriction#getValues()}.
+     */
+    @Test
+    public void testGetValues() throws Exception {
+        LocalRestriction lr2 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
+        assertArrayEquals(vals("item1", "item2"), lr2.getValues());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalRestriction#toString()}.
+     */
+    @Test
+    public void testToString() throws Exception {
+        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertNotNull(lr1.toString());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.jackrabbit.accessmanager.post.LocalRestriction#equals(java.lang.Object)}.
+     */
+    @Test
+    public void testEqualsObject() throws Exception {
+        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), val("/hello2"));
+        assertNotEquals(lr1, lr2);
+
+        LocalRestriction lr3 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertEquals(lr1, lr3);
+    }
+
+}

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
@@ -128,6 +128,9 @@ public class LocalRestrictionTest {
 
         LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), (Value)null);
         assertNull(lr2.getValue());
+
+        LocalRestriction lr3 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
+        assertEquals(val("item1"), lr3.getValue());
     }
 
     /**
@@ -152,6 +155,9 @@ public class LocalRestrictionTest {
     public void testToString() throws Exception {
         LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
         assertNotNull(lr1.toString());
+
+        LocalRestriction lr2 = new LocalRestriction(null, val("/hello1"));
+        assertNotNull(lr2.toString());
     }
 
     /**

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -124,6 +125,9 @@ public class LocalRestrictionTest {
     public void testGetValue() throws Exception {
         LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
         assertEquals(val("/hello1"), lr1.getValue());
+
+        LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), (Value)null);
+        assertNull(lr2.getValue());
     }
 
     /**
@@ -150,6 +154,10 @@ public class LocalRestrictionTest {
     @Test
     public void testEqualsObject() throws Exception {
         LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        assertEquals(lr1, lr1);
+        assertNotEquals(lr1, null);
+        assertNotEquals(lr1, this);
+
         LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), val("/hello2"));
         assertNotEquals(lr1, lr2);
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
@@ -131,6 +131,9 @@ public class LocalRestrictionTest {
 
         LocalRestriction lr3 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
         assertEquals(val("item1"), lr3.getValue());
+
+        LocalRestriction lr4 = new LocalRestriction(rd("rep:itemNames"), (Value[])new Value[0]);
+        assertNull(lr4.getValue());
     }
 
     /**


### PR DESCRIPTION
The restriction details in the ACL json output can be ambiguous in some situations.