### PR TITLE
SLING-11243 Redundant privileges contained in ACE

### DIFF
--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
@@ -598,9 +598,10 @@ public final class PrivilegesHelper {
                     boolean allRestrictionsSame = childLocalPrivileges.stream().allMatch(lp -> firstAllowRestrictions.equals(lp.getAllowRestrictions()));
                     if (allRestrictionsSame) {
                         alp.setAllowRestrictions(firstAllowRestrictions);
-
-                        // each child with the same restrictions can be unset
-                        for (LocalPrivilege lp : childLocalPrivileges) {
+                    }
+                    // each child with the same restrictions can be unset
+                    for (LocalPrivilege lp : childLocalPrivileges) {
+                        if (lp.sameAllowRestrictions(alp.getAllowRestrictions())) {
                             lp.setAllow(false);
                             lp.setAllowRestrictions(Collections.emptySet());
                         }
@@ -618,9 +619,10 @@ public final class PrivilegesHelper {
                     boolean allRestrictionsSame = childLocalPrivileges.stream().allMatch(lp -> firstDenyRestrictions.equals(lp.getDenyRestrictions()));
                     if (allRestrictionsSame) {
                         alp.setDenyRestrictions(firstDenyRestrictions);
-
-                        // each child with the same restrictions can be unset
-                        for (LocalPrivilege lp : childLocalPrivileges) {
+                    }
+                    // each child with the same restrictions can be unset
+                    for (LocalPrivilege lp : childLocalPrivileges) {
+                        if (lp.sameDenyRestrictions(alp.getDenyRestrictions())) {
                             lp.setDeny(false);
                             lp.setDenyRestrictions(Collections.emptySet());
                         }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
@@ -18,17 +18,21 @@ package org.apache.sling.jcr.jackrabbit.accessmanager.it;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
 
 import javax.json.JsonException;
 import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -133,6 +137,50 @@ public class GetAceIT extends AccessManagerClientTestSupport {
         String getUrl = testFolderUrl + "/child.ace.json?pid=" + testUserId;
         // no declared access control entry returns a 404
         assertAuthenticatedHttpStatus(creds, getUrl, HttpServletResponse.SC_NOT_FOUND, "Did not expect an ace to be returned");
+    }
+
+    /**
+     * ACE servlet returns restriction details for leaf of also allowed aggregate
+     */
+    @Test
+    public void testDeclaredAceWithLeafRestrictionForUser() throws IOException, JsonException {
+        commonDeclaredAceWithLeafRestrictionForUser(1);
+    }
+
+    protected void commonDeclaredAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
+        testUserId = createTestUser();
+        testFolderUrl = createTestFolder(null, "sling-tests",
+                "{ \"jcr:primaryType\": \"nt:unstructured\" }");
+
+        //1. create an initial set of privileges
+        List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
+                .withPrivilege(PrivilegeConstants.JCR_ALL, PrivilegeValues.ALLOW)
+                .withPrivilegeRestriction(PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE, AccessControlConstants.REP_GLOB, "glob1")
+                .build();
+        for (int i=0; i < numberOfUpdateAceCalls; i++) {
+            addOrUpdateAce(testFolderUrl, postParams);
+        }
+
+        JsonObject acePrivleges = getAcePrivleges(testFolderUrl, testUserId);
+        assertNotNull(acePrivleges);
+        assertEquals(2, acePrivleges.size());
+        //allow privilege
+        assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_ALL,
+                true, jsonValue -> {
+                    assertNotNull(jsonValue);
+                    assertEquals(JsonValue.TRUE, jsonValue);
+                });
+        assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE,
+                true, jsonValue -> {
+                    assertNotNull(jsonValue);
+                    assertTrue(jsonValue instanceof JsonObject);
+                    JsonObject restrictionsObj = (JsonObject)jsonValue;
+
+                    JsonValue repGlobValue = restrictionsObj.get(AccessControlConstants.REP_GLOB);
+                    assertNotNull(repGlobValue);
+                    assertTrue(repGlobValue instanceof JsonString);
+                    assertEquals("glob1", ((JsonString)repGlobValue).getString());
+                });
     }
 
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
@@ -18,17 +18,21 @@ package org.apache.sling.jcr.jackrabbit.accessmanager.it;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
 
 import javax.json.JsonException;
 import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -133,5 +137,64 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
         String getUrl = testFolderUrl + ".eace.json?pid=" + testUserId;
         assertAuthenticatedHttpStatus(creds, getUrl, HttpServletResponse.SC_NOT_FOUND, "Did not expect an ace to be returned");
     }
+
+
+    /**
+     * ACE servlet returns restriction details for leaf of also allowed aggregate
+     */
+    @Test
+    public void testEffectiveAceWithLeafRestrictionForUser() throws IOException, JsonException {
+        commonEffectiveAceWithLeafRestrictionForUser(1);
+    }
+
+    protected void commonEffectiveAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
+        testUserId = createTestUser();
+        testFolderUrl = createTestFolder(null, "sling-tests2",
+                "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
+
+        //1. create an initial set of privileges
+        List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
+                .withPrivilege(PrivilegeConstants.JCR_ALL, PrivilegeValues.ALLOW)
+                .withPrivilegeRestriction(PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE, AccessControlConstants.REP_GLOB, "glob1")
+                .build();
+        for (int i=0; i < numberOfUpdateAceCalls; i++) {
+            addOrUpdateAce(testFolderUrl, postParams);
+        }
+
+        //fetch the JSON for the ace to verify the settings.
+        String getUrl = testFolderUrl + "/child.eace.json?pid=" + testUserId;
+
+        Credentials creds = new UsernamePasswordCredentials(testUserId, "testPwd");
+
+        String json = getAuthenticatedContent(creds, getUrl, CONTENT_TYPE_JSON, HttpServletResponse.SC_OK);
+        assertNotNull(json);
+        assertNotNull(json);
+        JsonObject aceObject = parseJson(json);
+
+        String principalString = aceObject.getString("principal");
+        assertEquals(testUserId, principalString);
+
+        JsonObject eacePrivleges = aceObject.getJsonObject("privileges");
+        assertNotNull(eacePrivleges);
+        assertEquals(2, eacePrivleges.size());
+        //allow privilege
+        assertPrivilege(eacePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_ALL,
+                true, jsonValue -> {
+                    assertNotNull(jsonValue);
+                    assertEquals(JsonValue.TRUE, jsonValue);
+                });
+        assertPrivilege(eacePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE,
+                true, jsonValue -> {
+                    assertNotNull(jsonValue);
+                    assertTrue(jsonValue instanceof JsonObject);
+                    JsonObject restrictionsObj = (JsonObject)jsonValue;
+
+                    JsonValue repGlobValue = restrictionsObj.get(AccessControlConstants.REP_GLOB);
+                    assertNotNull(repGlobValue);
+                    assertTrue(repGlobValue instanceof JsonString);
+                    assertEquals("glob1", ((JsonString)repGlobValue).getString());
+                });
+    }
+
 
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
@@ -16,15 +16,23 @@
  */
 package org.apache.sling.jcr.jackrabbit.accessmanager.it;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.List;
 
 import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -123,5 +131,52 @@ public class GetPaceIT extends PrincipalAceTestSupport {
         String targetUrl = String.format("%s/not_existing_path", baseServerUri);
         commonPrivilegeAceForServiceUser(targetUrl, "pace");
     }
+
+
+    /**
+     * ACE servlet returns restriction details for leaf of also allowed aggregate
+     */
+    @Test
+    public void testPrivilegeAceWithLeafRestrictionForUser() throws IOException, JsonException {
+        commonPrivilegeAceWithLeafRestrictionForUser(1);
+    }
+
+    protected void commonPrivilegeAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
+        testFolderUrl = createTestFolder(null, "sling-tests",
+                "{ \"jcr:primaryType\": \"nt:unstructured\" }");
+        String testServiceUserId = "pacetestuser";
+
+        //1. create an initial set of privileges
+        List<NameValuePair> postParams = new AcePostParamsBuilder(testServiceUserId)
+                .withPrivilege(PrivilegeConstants.JCR_ALL, PrivilegeValues.ALLOW)
+                .withPrivilegeRestriction(PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE, AccessControlConstants.REP_GLOB, "glob1")
+                .build();
+        for (int i=0; i < numberOfUpdateAceCalls; i++) {
+            addOrUpdatePrincipalAce(testFolderUrl, postParams);
+        }
+
+        JsonObject principalAce = getPrincipalAce(testFolderUrl, testServiceUserId);
+        JsonObject acePrivleges = principalAce.getJsonObject("privileges");
+        assertNotNull(acePrivleges);
+        assertEquals(2, acePrivleges.size());
+        //allow privilege
+        assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_ALL,
+                true, jsonValue -> {
+                    assertNotNull(jsonValue);
+                    assertEquals(JsonValue.TRUE, jsonValue);
+                });
+        assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE,
+                true, jsonValue -> {
+                    assertNotNull(jsonValue);
+                    assertTrue(jsonValue instanceof JsonObject);
+                    JsonObject restrictionsObj = (JsonObject)jsonValue;
+
+                    JsonValue repGlobValue = restrictionsObj.get(AccessControlConstants.REP_GLOB);
+                    assertNotNull(repGlobValue);
+                    assertTrue(repGlobValue instanceof JsonString);
+                    assertEquals("glob1", ((JsonString)repGlobValue).getString());
+                });
+    }
+
 
 }


### PR DESCRIPTION
Redundant privileges may be contained in ACE when setting restriction details for a privilege that is part of an already allowed aggregate

Use case: Posting a modifyAce request with fields like this:
- privilege@jcr:all=allow
- restriction@jcr:removeNode@rep:itemNames@Allow=item1

Before this fix the ACE output contained some redundant privileges that are already covered by jcr:all like this:
`{
  "principal":"everyone",
  "privileges":{
    "jcr:addChildNodes":{
      "allow":true
    },
    "jcr:removeNode":{
      "allow":{
        "rep:itemNames":[
          "item1"
        ]
      }
    },
    "jcr:removeChildNodes":{
      "allow":true
    },
    "jcr:all":{
      "allow":true
    },
    "jcr:modifyProperties":{
      "allow":true
    }
  }
}`

After the fix, the redundant privileges are not there like this:
`{
  "principal":"everyone",
  "privileges":{
    "jcr:removeNode":{
      "allow":{
        "rep:itemNames":[
          "item1"
        ]
      }
    },
    "jcr:all":{
      "allow":true
    }
  }
}`