### PR TITLE
SLING-11243 modifyace post a second time reverses the entry order

### DIFF
--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAclServlet.java
@@ -16,21 +16,18 @@
  */
 package org.apache.sling.jcr.jackrabbit.accessmanager.post;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
-import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
 import javax.json.JsonObject;
 import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetAcl;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -124,17 +121,10 @@ public class GetAclServlet extends AbstractGetAclServlet implements GetAcl {
     }
 
     @Override
-    protected AccessControlEntry[] getAccessControlEntries(Session session, String absPath) throws RepositoryException {
-        AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+    protected Map<String, List<AccessControlEntry>> getAccessControlEntriesMap(Session session, String absPath) throws RepositoryException {
+        AccessControlManager accessControlManager = session.getAccessControlManager();
         AccessControlPolicy[] policies = accessControlManager.getPolicies(absPath);
-        List<AccessControlEntry> allEntries = new ArrayList<>(); 
-        for (AccessControlPolicy accessControlPolicy : policies) {
-            if (accessControlPolicy instanceof AccessControlList) {
-                AccessControlEntry[] accessControlEntries = ((AccessControlList)accessControlPolicy).getAccessControlEntries();
-                allEntries.addAll(Arrays.asList(accessControlEntries));
-            }
-        }
-        return allEntries.toArray(new AccessControlEntry[allEntries.size()]);
+        return entriesSortedByEffectivePath(policies, ace -> true);
     }
 
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAceServlet.java
@@ -19,14 +19,12 @@
 package org.apache.sling.jcr.jackrabbit.accessmanager.post;
 
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.Map;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
-import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
 import javax.json.JsonObject;
@@ -95,19 +93,11 @@ public class GetEffectiveAceServlet extends AbstractGetAceServlet implements Get
     }
 
     @Override
-    protected AccessControlEntry[] getAccessControlEntries(Session session, String absPath, Principal principal) throws RepositoryException {
+    protected Map<String, List<AccessControlEntry>> getAccessControlEntriesMap(Session session, String absPath,
+            Principal principal) throws RepositoryException {
         AccessControlManager acMgr = AccessControlUtil.getAccessControlManager(session);
         AccessControlPolicy[] policies = acMgr.getEffectivePolicies(absPath);
-        List<AccessControlEntry> allEntries = new ArrayList<>(); 
-        for (AccessControlPolicy policy : policies) {
-            if (policy instanceof AccessControlList) {
-                AccessControlEntry[] accessControlEntries = ((AccessControlList)policy).getAccessControlEntries();
-                Stream.of(accessControlEntries)
-                    .filter(entry -> principal.equals(entry.getPrincipal()))
-                    .forEach(allEntries::add);
-            }
-        }
-        return allEntries.toArray(new AccessControlEntry[allEntries.size()]);
+        return entriesSortedByEffectivePath(policies, ace -> principal.equals(ace.getPrincipal()));
     }
 
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAclServlet.java
@@ -16,21 +16,18 @@
  */
 package org.apache.sling.jcr.jackrabbit.accessmanager.post;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
-import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
 import javax.json.JsonObject;
 import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetEffectiveAcl;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -124,17 +121,10 @@ public class GetEffectiveAclServlet extends AbstractGetAclServlet implements Get
     }
 
     @Override
-    protected AccessControlEntry[] getAccessControlEntries(Session session, String absPath) throws RepositoryException {
-        AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+    protected Map<String, List<AccessControlEntry>> getAccessControlEntriesMap(Session session, String absPath) throws RepositoryException {
+        AccessControlManager accessControlManager = session.getAccessControlManager();
         AccessControlPolicy[] policies = accessControlManager.getEffectivePolicies(absPath);
-        List<AccessControlEntry> allEntries = new ArrayList<>(); 
-        for (AccessControlPolicy accessControlPolicy : policies) {
-            if (accessControlPolicy instanceof AccessControlList) {
-                AccessControlEntry[] accessControlEntries = ((AccessControlList)accessControlPolicy).getAccessControlEntries();
-                allEntries.addAll(Arrays.asList(accessControlEntries));
-            }
-        }
-        return allEntries.toArray(new AccessControlEntry[allEntries.size()]);
+        return entriesSortedByEffectivePath(policies, ace -> true);
     }
 
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyPrincipalAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyPrincipalAceServlet.java
@@ -28,6 +28,7 @@ import javax.jcr.Value;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
+import javax.jcr.security.Privilege;
 import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
@@ -211,12 +212,14 @@ public class ModifyPrincipalAceServlet extends ModifyAceServlet implements Modif
     @Override
     protected void addAces(@NotNull String resourcePath, @NotNull Principal principal,
             @NotNull Map<Set<LocalRestriction>, List<LocalPrivilege>> restrictionsToLocalPrivilegesMap, boolean isAllow,
-            @NotNull JackrabbitAccessControlList acl) throws RepositoryException {
-        if (!isAllow && !restrictionsToLocalPrivilegesMap.isEmpty()) {
+            @NotNull JackrabbitAccessControlList acl, Map<Privilege, Integer> privilegeLongestDepthMap)
+            throws RepositoryException {
+        if (isAllow) {
+            super.addAces(resourcePath, principal, restrictionsToLocalPrivilegesMap, isAllow, acl, privilegeLongestDepthMap);
+        } else if (!restrictionsToLocalPrivilegesMap.isEmpty()) {
             // deny privileges not allowed in a principal ACE
             throw new IllegalArgumentException("Deny privileges are not allowed in a principal ACE");
         }
-        super.addAces(resourcePath, principal, restrictionsToLocalPrivilegesMap, isAllow, acl);
     }
 
     /**

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
@@ -147,6 +147,15 @@ public class GetAceIT extends AccessManagerClientTestSupport {
         commonDeclaredAceWithLeafRestrictionForUser(1);
     }
 
+    /**
+     * ACE servlet returns restriction details for leaf of also allowed aggregate after a second
+     * update to verify that the ordering doesn't get broken during update
+     */
+    @Test
+    public void testDeclaredAceWithLeafRestrictionForUserAfterSecondUpdate() throws IOException, JsonException {
+        commonDeclaredAceWithLeafRestrictionForUser(2);
+    }
+
     protected void commonDeclaredAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests",

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
@@ -147,6 +147,15 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
         commonEffectiveAceWithLeafRestrictionForUser(1);
     }
 
+    /**
+     * ACE servlet returns restriction details for leaf of also allowed aggregate after a second
+     * update to verify that the ordering doesn't get broken during update
+     */
+    @Test
+    public void testEffectiveAceWithLeafRestrictionForUserAfterSecondUpdate() throws IOException, JsonException {
+        commonEffectiveAceWithLeafRestrictionForUser(2);
+    }
+
     protected void commonEffectiveAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests2",

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
@@ -141,6 +141,15 @@ public class GetPaceIT extends PrincipalAceTestSupport {
         commonPrivilegeAceWithLeafRestrictionForUser(1);
     }
 
+    /**
+     * ACE servlet returns restriction details for leaf of also allowed aggregate after a second
+     * update to verify that the ordering doesn't get broken during update
+     */
+    @Test
+    public void testPrivilegeAceWithLeafRestrictionForUserAfterSecondUpdate() throws IOException, JsonException {
+        commonPrivilegeAceWithLeafRestrictionForUser(2);
+    }
+
     protected void commonPrivilegeAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
         testFolderUrl = createTestFolder(null, "sling-tests",
                 "{ \"jcr:primaryType\": \"nt:unstructured\" }");


### PR DESCRIPTION
The entries for the principal get reversed on the second update which can make a more specific entry not get used

Use case: Posting a modifyAce request with fields like this and then posting the same again:
privilege@jcr:all=allow
restriction@jcr:removeNode@rep:itemNames@Allow=item1

Expected:
The entries in the ACL should keep the entry with the restriction after the "jcr:all" entry after the second update.
