### PR TITLE
SLING-11243 merge multivalue restriction values for eace/eacl json

### DIFF
--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/LocalRestriction.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/LocalRestriction.java
@@ -102,4 +102,11 @@ public class LocalRestriction {
         return Arrays.equals(values, other.values);
     }
 
+    /**
+     * Clone from an existing object and then assign the new values
+     */
+    public static @NotNull LocalRestriction cloneWithNewValues(@NotNull LocalRestriction lr, @NotNull Value[] newValues) {
+        return new LocalRestriction(lr.rd, newValues);
+    }
+
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
@@ -21,7 +21,6 @@ package org.apache.sling.jcr.jackrabbit.accessmanager.impl;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -268,26 +267,20 @@ public final class PrivilegesHelper {
         forAllow &= localPrivilege.isAllow();
         forDeny &= localPrivilege.isDeny();
         if (forAllow) {
-            Set<LocalRestriction> allowRestrictions = new HashSet<>(localPrivilege.getAllowRestrictions());
-            if (allowRestrictions.removeIf(lr -> restrictionNames.contains(lr.getName()))) {
-                localPrivilege.setAllowRestrictions(allowRestrictions);
-            }
+            localPrivilege.unsetAllowRestrictions(restrictionNames);
         }
         if (forDeny) {
-            Set<LocalRestriction> denyRestrictions = new HashSet<>(localPrivilege.getDenyRestrictions());
-            if (denyRestrictions.removeIf(lr -> restrictionNames.contains(lr.getName()))) {
-                localPrivilege.setDenyRestrictions(denyRestrictions);
-            }
+            localPrivilege.unsetDenyRestrictions(restrictionNames);
         }
 
         if (localPrivilege.sameAllowAndDenyRestrictions()) {
             // same restrictions so we can unset one of them
             if (forAllow) {
                 localPrivilege.setDeny(false);
-                localPrivilege.setDenyRestrictions(Collections.emptySet());
+                localPrivilege.clearDenyRestrictions();
             } else if (forDeny) {
                 localPrivilege.setAllow(false);
-                localPrivilege.setAllowRestrictions(Collections.emptySet());
+                localPrivilege.clearAllowRestrictions();
             }
         }
 
@@ -341,22 +334,18 @@ public final class PrivilegesHelper {
             if (requireAllowOrDenyAlreadySet && !localPrivilege.isDeny()) {
                 //skip it
             } else {
-                Set<LocalRestriction> denyRestrictions = new HashSet<>(localPrivilege.getDenyRestrictions());
-                denyRestrictions.removeIf(lr -> lr.getName().equals(restriction.getName()));
-                denyRestrictions.add(restriction);
                 localPrivilege.setDeny(true);
-                localPrivilege.setDenyRestrictions(denyRestrictions);
+                localPrivilege.unsetDenyRestrictions(Collections.singleton(restriction.getName()));
+                localPrivilege.setDenyRestrictions(Collections.singleton(restriction));
             }
         }
         if (forAllow) {
             if (requireAllowOrDenyAlreadySet && !localPrivilege.isAllow()) {
                 //skip it
             } else {
-                Set<LocalRestriction> allowRestrictions = new HashSet<>(localPrivilege.getAllowRestrictions());
-                allowRestrictions.removeIf(lr -> lr.getName().equals(restriction.getName()));
-                allowRestrictions.add(restriction);
                 localPrivilege.setAllow(true);
-                localPrivilege.setAllowRestrictions(allowRestrictions);
+                localPrivilege.unsetAllowRestrictions(Collections.singleton(restriction.getName()));
+                localPrivilege.setAllowRestrictions(Collections.singleton(restriction));
             }
         }
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
@@ -273,7 +273,7 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
     }
     protected void assertPrivilege(JsonObject privilegesObject, boolean expectedPrivilege, PrivilegeValues privilegeState, String privilegeName,
             VerifyAce verifyAce) {
-        assertPrivilege(privilegesObject, expectedPrivilege, privilegeState, privilegeName, true, null);
+        assertPrivilege(privilegesObject, expectedPrivilege, privilegeState, privilegeName, true, verifyAce);
     }
     protected void assertPrivilege(JsonObject privilegesObject, boolean expectedPrivilege, PrivilegeValues privilegeState, String privilegeName,
             boolean expectedForAllow,

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
@@ -2218,13 +2218,13 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
         // update the ACE
         List<NameValuePair> postParams = new AcePostParamsBuilder(testGroupId)
             .withPrivilegeRestriction(PrivilegeValues.ALLOW, PrivilegeConstants.JCR_READ, AccessControlConstants.REP_GLOB, "/hello")
-            .withPrivilegeRestriction(PrivilegeValues.NONE, PrivilegeConstants.JCR_READ, AccessControlConstants.REP_GLOB, "/hello")
+            .withPrivilegeRestriction(PrivilegeValues.DENY, PrivilegeConstants.JCR_READ, AccessControlConstants.REP_GLOB, "/hello")
             .build();
         addOrUpdateAce(testFolderUrl, postParams);
         JsonObject groupPrivilegesObject = getAcePrivleges(testFolderUrl, testGroupId);
         assertEquals(1, groupPrivilegesObject.size());
 
-        //allow privilege is there (allow prefererred over deny)
+        //allow privilege is there (allow preferred over deny)
         //allow privilege
         assertPrivilege(groupPrivilegesObject, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_READ, true, jsonValue -> {
             assertNotNull(jsonValue);

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
@@ -36,6 +36,7 @@ import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
 
 import org.apache.jackrabbit.oak.security.authorization.restriction.RestrictionProviderImpl;
+import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
@@ -196,7 +197,7 @@ public class LocalPrivilegeTest {
         assertTrue(allowRestrictions.isEmpty());
 
         Set<LocalRestriction> newAllowRestrictions = new HashSet<>();
-        newAllowRestrictions.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newAllowRestrictions.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
         lp1.setAllowRestrictions(newAllowRestrictions);
         Set<LocalRestriction> allowRestrictions2 = lp1.getAllowRestrictions();
         assertNotNull(allowRestrictions2);
@@ -215,7 +216,7 @@ public class LocalPrivilegeTest {
         assertTrue(denyRestrictions.isEmpty());
 
         Set<LocalRestriction> newDenyRestrictions = new HashSet<>();
-        newDenyRestrictions.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
+        newDenyRestrictions.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
         lp1.setDenyRestrictions(newDenyRestrictions);
         Set<LocalRestriction> denyRestrictions2 = lp1.getDenyRestrictions();
         assertNotNull(denyRestrictions2);
@@ -233,20 +234,20 @@ public class LocalPrivilegeTest {
         assertTrue(lp1.sameAllowRestrictions(lp2.getAllowRestrictions()));
 
         Set<LocalRestriction> newAllowRestrictions1 = new HashSet<>();
-        newAllowRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newAllowRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        newAllowRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newAllowRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2")));
         lp1.setAllowRestrictions(newAllowRestrictions1);
         assertFalse(lp1.sameAllowRestrictions(lp2.getAllowRestrictions()));
 
         Set<LocalRestriction> newAllowRestrictions2 = new HashSet<>();
-        newAllowRestrictions2.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newAllowRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        newAllowRestrictions2.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newAllowRestrictions2.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2")));
         lp2.setAllowRestrictions(newAllowRestrictions2);
         assertTrue(lp1.sameAllowRestrictions(lp2.getAllowRestrictions()));
 
         Set<LocalRestriction> newAllowRestrictions3 = new HashSet<>();
-        newAllowRestrictions3.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newAllowRestrictions3.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2_changed")));
+        newAllowRestrictions3.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newAllowRestrictions3.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2_changed")));
         lp2.setAllowRestrictions(newAllowRestrictions3);
         assertFalse(lp1.sameAllowRestrictions(lp2.getAllowRestrictions()));
     }
@@ -261,20 +262,20 @@ public class LocalPrivilegeTest {
         assertTrue(lp1.sameDenyRestrictions(lp2.getDenyRestrictions()));
 
         Set<LocalRestriction> newDenyRestrictions1 = new HashSet<>();
-        newDenyRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newDenyRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        newDenyRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newDenyRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2")));
         lp1.setDenyRestrictions(newDenyRestrictions1);
         assertFalse(lp1.sameDenyRestrictions(lp2.getDenyRestrictions()));
 
         Set<LocalRestriction> newDenyRestrictions2 = new HashSet<>();
-        newDenyRestrictions2.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newDenyRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        newDenyRestrictions2.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newDenyRestrictions2.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2")));
         lp2.setDenyRestrictions(newDenyRestrictions2);
         assertTrue(lp1.sameDenyRestrictions(lp2.getDenyRestrictions()));
 
         Set<LocalRestriction> newDenyRestrictions3 = new HashSet<>();
-        newDenyRestrictions3.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newDenyRestrictions3.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2_changed")));
+        newDenyRestrictions3.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newDenyRestrictions3.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2_changed")));
         lp2.setDenyRestrictions(newDenyRestrictions3);
         assertFalse(lp1.sameDenyRestrictions(lp2.getDenyRestrictions()));
     }
@@ -288,20 +289,20 @@ public class LocalPrivilegeTest {
         assertTrue(lp1.sameAllowAndDenyRestrictions());
 
         Set<LocalRestriction> newDenyRestrictions1 = new HashSet<>();
-        newDenyRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newDenyRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        newDenyRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newDenyRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2")));
         lp1.setDenyRestrictions(newDenyRestrictions1);
         assertFalse(lp1.sameAllowAndDenyRestrictions());
 
         Set<LocalRestriction> newAllowRestrictions1 = new HashSet<>();
-        newAllowRestrictions1.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newAllowRestrictions1.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2")));
+        newAllowRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newAllowRestrictions1.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2")));
         lp1.setAllowRestrictions(newAllowRestrictions1);
         assertTrue(lp1.sameAllowAndDenyRestrictions());
 
         Set<LocalRestriction> newAllowRestrictions2 = new HashSet<>();
-        newAllowRestrictions2.add(new LocalRestriction(rd("rep:glob"), val("/hello")));
-        newAllowRestrictions2.add(new LocalRestriction(rd("nt:itemNames"), vals("item1", "item2_changed")));
+        newAllowRestrictions2.add(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")));
+        newAllowRestrictions2.add(new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2_changed")));
         lp1.setAllowRestrictions(newAllowRestrictions2);
         assertFalse(lp1.sameAllowAndDenyRestrictions());
     }
@@ -358,12 +359,12 @@ public class LocalPrivilegeTest {
         assertNotEquals(lp10, lp11);
 
         LocalPrivilege lp12 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
-        lp12.setAllowRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(rd("rep:glob"), val("/hello")))));
+        lp12.setAllowRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")))));
         LocalPrivilege lp13 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         assertNotEquals(lp12, lp13);
 
         LocalPrivilege lp14 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
-        lp14.setDenyRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(rd("rep:glob"), val("/hello")))));
+        lp14.setDenyRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello")))));
         LocalPrivilege lp15 = new LocalPrivilege(priv(PrivilegeConstants.JCR_READ));
         assertNotEquals(lp14, lp15);
 


### PR DESCRIPTION
If a parent node has one set of values for a restriction and the child node has a different set of values for the same restriction, then the effective ACE view of the child node should have both of those value sets merged together.

For example, consider this use case: 
Post a modifyAce request with fields like this on a parent node:
```
privilege@rep:readProperties=deny
restriction@rep:readProperties@rep:itemNames@Allow=item1
```
Post a modifyAce request with fields like this on the child node:
`restriction@rep:readProperties@rep:itemNames@Allow=item2`

The expected output for the effective ace of the child node should have both values:
```
{
  "principal": "testuser1",
  "privileges": {
    "rep:readProperties": {
      "allow": {
        "rep:itemNames": [
          "item1",
          "item2"
        ]
      },
      "deny": true
    },
    "jcr:read": {
      "allow": true
    }
  },
  "declaredAt": {
    "node": [
      "/content/pages",
      "/content/pages/subpage1"
    ]
  }
}
```