### PR TITLE
SLING-11243 handle conflict between aggregate and leaf

### DIFF
--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/LocalRestriction.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/LocalRestriction.java
@@ -69,7 +69,7 @@ public class LocalRestriction {
         builder.append("LocalRestriction [name=");
         builder.append(rd == null ? null : rd.getName());
         builder.append(", value=");
-        builder.append(getValues());
+        builder.append(Arrays.toString(getValues()));
         builder.append("]");
         return builder.toString();
     }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
@@ -291,14 +291,14 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
             assertNotNull(privilegeObj);
             String key = privilegeState.toString();;
             if (expectedForAllow) {
-                assertTrue("Expected privilege " + privilegeName + " to have key '" + key,
+                assertTrue("Expected privilege " + privilegeName + " to have key: " + key,
                         privilegeObj.containsKey(key));
                 JsonValue jsonValue = privilegeObj.get(key);
                 if (verifyAce != null) {
                     verifyAce.verify(jsonValue);
                 }
             } else {
-                assertFalse("Did not expect privilege " + privilegeName + " to have key '" + key,
+                assertFalse("Did not expect privilege " + privilegeName + " to have key: " + key,
                         privilegeObj.containsKey(key));
             }
         }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
@@ -290,7 +290,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
         assertNotNull(jsonContent);
         JsonObject jsonObject = parseJson(jsonContent);
         assertTrue("Expected childPropOne property", jsonObject.containsKey("childPropOne"));
-        assertFalse("Did not expected childPropTwo property", jsonObject.containsKey("childPropTwo"));
+        assertFalse("Did not expect childPropTwo property", jsonObject.containsKey("childPropTwo"));
 
         // add ACE to the child to make the other property readable
         List<NameValuePair> postParams2 = new AcePostParamsBuilder(testUserId)


### PR DESCRIPTION
Modifying an ACE should not include a allow/deny aggregate privilege when there is a deny/allow child privilege with the same restrictions as the parent

For example, consider this use case with a modifyAce request with fields like this on a parent node:

```
//allow the child privileges with varying restrictions
privilege@rep:readNodes=allow
privilege@rep:readProperties=allow
restriction@rep:readProperties@rep:itemNames@Allow=jcr:created

//and deny a child privilege with the same restrictions as the aggregate would get
privilege@rep:readProperties=deny
```

The expected ace of the child node should not have the jcr:read privilege set as allowed:

```
{
  "principal":"testuser1",
  "privileges":{
    "rep:readProperties":{
      "allow":{
        "rep:itemNames":[
          "jcr:created"
        ]
      },
      "deny":true
    },
    "rep:readNodes":{
      "allow":true
    }
  }
}
```