### PR TITLE
SLING-11243 avoid an ambiguous ACE definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.0.0</version>
+            <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelper.java
@@ -680,21 +680,11 @@ public final class PrivilegesHelper {
                     //  and unset the data from each child
                     Set<LocalRestriction> firstAllowRestrictions = childLocalPrivileges.get(0).getAllowRestrictions();
                     boolean allRestrictionsSame = childLocalPrivileges.stream().allMatch(lp -> firstAllowRestrictions.equals(lp.getAllowRestrictions()));
-                    Set<LocalRestriction> restrictions;
                     if (allRestrictionsSame) {
-                        restrictions = firstAllowRestrictions;
-                    } else {
-                        restrictions = Collections.emptySet();
-                    }
-
-                    // if any deny child has the same restrictions, then the parent should not be set
-                    //   as that would cause the deny privilege to get excluded when persisted
-                    boolean anyDenyWithSameRestrictions = childLocalPrivileges.stream().anyMatch(p -> p.isDeny() && p.sameDenyRestrictions(restrictions));
-                    if (!anyDenyWithSameRestrictions) {
                         // all the child privileges are allow so we can mark the parent as allow
                         LocalPrivilege alp = privilegeToLocalPrivilegesMap.computeIfAbsent(aggregatePrivilege, LocalPrivilege::new);
                         alp.setAllow(true);
-                        alp.setAllowRestrictions(restrictions);
+                        alp.setAllowRestrictions(firstAllowRestrictions);
 
                         // each child with the same restrictions can be unset
                         for (LocalPrivilege lp : childLocalPrivileges) {
@@ -711,21 +701,11 @@ public final class PrivilegesHelper {
                     //  and unset the data from each child
                     Set<LocalRestriction> firstDenyRestrictions = childLocalPrivileges.get(0).getDenyRestrictions();
                     boolean allRestrictionsSame = childLocalPrivileges.stream().allMatch(lp -> firstDenyRestrictions.equals(lp.getDenyRestrictions()));
-                    Set<LocalRestriction> restrictions;
                     if (allRestrictionsSame) {
-                        restrictions = firstDenyRestrictions;
-                    } else {
-                        restrictions = Collections.emptySet();
-                    }
-
-                    // if any allow child has the same restrictions, then the parent should not be set
-                    //   as that would cause the allow privilege to get excluded when persisted
-                    boolean anyAllowWithSameRestrictions = childLocalPrivileges.stream().anyMatch(p -> p.isAllow() && p.sameAllowRestrictions(restrictions));
-                    if (!anyAllowWithSameRestrictions) {
                         // all the child privileges are deny so we can mark the parent as deny
                         LocalPrivilege alp = privilegeToLocalPrivilegesMap.computeIfAbsent(aggregatePrivilege, LocalPrivilege::new);
                         alp.setDeny(true);
-                        alp.setDenyRestrictions(restrictions);
+                        alp.setDenyRestrictions(firstDenyRestrictions);
 
                         // each child with the same restrictions can be unset
                         for (LocalPrivilege lp : childLocalPrivileges) {

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.json.JsonException;
 import javax.json.JsonObject;
@@ -172,13 +173,24 @@ public class GetAceIT extends AccessManagerClientTestSupport {
 
         JsonObject acePrivleges = getAcePrivleges(testFolderUrl, testUserId);
         assertNotNull(acePrivleges);
-        assertEquals(2, acePrivleges.size());
+        assertEquals(18, acePrivleges.size());
         //allow privilege
-        assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_ALL,
-                true, jsonValue -> {
-                    assertNotNull(jsonValue);
-                    assertEquals(JsonValue.TRUE, jsonValue);
-                });
+        Stream.of(PrivilegeConstants.JCR_MODIFY_ACCESS_CONTROL, PrivilegeConstants.JCR_VERSION_MANAGEMENT,
+                PrivilegeConstants.JCR_READ, PrivilegeConstants.REP_USER_MANAGEMENT,
+                PrivilegeConstants.JCR_ADD_CHILD_NODES, PrivilegeConstants.JCR_NAMESPACE_MANAGEMENT,
+                PrivilegeConstants.JCR_READ_ACCESS_CONTROL, PrivilegeConstants.JCR_NODE_TYPE_DEFINITION_MANAGEMENT,
+                PrivilegeConstants.JCR_LOCK_MANAGEMENT, PrivilegeConstants.JCR_RETENTION_MANAGEMENT,
+                PrivilegeConstants.JCR_LIFECYCLE_MANAGEMENT, PrivilegeConstants.JCR_NODE_TYPE_MANAGEMENT,
+                PrivilegeConstants.JCR_REMOVE_CHILD_NODES, PrivilegeConstants.JCR_MODIFY_PROPERTIES,
+                PrivilegeConstants.REP_INDEX_DEFINITION_MANAGEMENT, PrivilegeConstants.REP_PRIVILEGE_MANAGEMENT,
+                PrivilegeConstants.JCR_WORKSPACE_MANAGEMENT)
+            .forEach(privilege -> {
+                assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, privilege,
+                        true, jsonValue -> {
+                            assertNotNull(jsonValue);
+                            assertEquals(JsonValue.TRUE, jsonValue);
+                        });
+            });
         assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE,
                 true, jsonValue -> {
                     assertNotNull(jsonValue);

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.json.JsonArray;
 import javax.json.JsonException;
@@ -193,13 +194,24 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
 
         JsonObject eacePrivleges = aceObject.getJsonObject("privileges");
         assertNotNull(eacePrivleges);
-        assertEquals(2, eacePrivleges.size());
+        assertEquals(18, eacePrivleges.size());
         //allow privilege
-        assertPrivilege(eacePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_ALL,
-                true, jsonValue -> {
-                    assertNotNull(jsonValue);
-                    assertEquals(JsonValue.TRUE, jsonValue);
-                });
+        Stream.of(PrivilegeConstants.JCR_MODIFY_ACCESS_CONTROL, PrivilegeConstants.JCR_VERSION_MANAGEMENT,
+                PrivilegeConstants.JCR_READ, PrivilegeConstants.REP_USER_MANAGEMENT,
+                PrivilegeConstants.JCR_ADD_CHILD_NODES, PrivilegeConstants.JCR_NAMESPACE_MANAGEMENT,
+                PrivilegeConstants.JCR_READ_ACCESS_CONTROL, PrivilegeConstants.JCR_NODE_TYPE_DEFINITION_MANAGEMENT,
+                PrivilegeConstants.JCR_LOCK_MANAGEMENT, PrivilegeConstants.JCR_RETENTION_MANAGEMENT,
+                PrivilegeConstants.JCR_LIFECYCLE_MANAGEMENT, PrivilegeConstants.JCR_NODE_TYPE_MANAGEMENT,
+                PrivilegeConstants.JCR_REMOVE_CHILD_NODES, PrivilegeConstants.JCR_MODIFY_PROPERTIES,
+                PrivilegeConstants.REP_INDEX_DEFINITION_MANAGEMENT, PrivilegeConstants.REP_PRIVILEGE_MANAGEMENT,
+                PrivilegeConstants.JCR_WORKSPACE_MANAGEMENT)
+            .forEach(privilege -> {
+                assertPrivilege(eacePrivleges, true, PrivilegeValues.ALLOW, privilege,
+                        true, jsonValue -> {
+                            assertNotNull(jsonValue);
+                            assertEquals(JsonValue.TRUE, jsonValue);
+                        });
+            });
         assertPrivilege(eacePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE,
                 true, jsonValue -> {
                     assertNotNull(jsonValue);

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.json.JsonArray;
 import javax.json.JsonException;
@@ -169,13 +170,24 @@ public class GetPaceIT extends PrincipalAceTestSupport {
         JsonObject principalAce = getPrincipalAce(testFolderUrl, testServiceUserId);
         JsonObject acePrivleges = principalAce.getJsonObject("privileges");
         assertNotNull(acePrivleges);
-        assertEquals(2, acePrivleges.size());
+        assertEquals(18, acePrivleges.size());
         //allow privilege
-        assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_ALL,
-                true, jsonValue -> {
-                    assertNotNull(jsonValue);
-                    assertEquals(JsonValue.TRUE, jsonValue);
-                });
+        Stream.of(PrivilegeConstants.JCR_MODIFY_ACCESS_CONTROL, PrivilegeConstants.JCR_VERSION_MANAGEMENT,
+                PrivilegeConstants.JCR_READ, PrivilegeConstants.REP_USER_MANAGEMENT,
+                PrivilegeConstants.JCR_ADD_CHILD_NODES, PrivilegeConstants.JCR_NAMESPACE_MANAGEMENT,
+                PrivilegeConstants.JCR_READ_ACCESS_CONTROL, PrivilegeConstants.JCR_NODE_TYPE_DEFINITION_MANAGEMENT,
+                PrivilegeConstants.JCR_LOCK_MANAGEMENT, PrivilegeConstants.JCR_RETENTION_MANAGEMENT,
+                PrivilegeConstants.JCR_LIFECYCLE_MANAGEMENT, PrivilegeConstants.JCR_NODE_TYPE_MANAGEMENT,
+                PrivilegeConstants.JCR_REMOVE_CHILD_NODES, PrivilegeConstants.JCR_MODIFY_PROPERTIES,
+                PrivilegeConstants.REP_INDEX_DEFINITION_MANAGEMENT, PrivilegeConstants.REP_PRIVILEGE_MANAGEMENT,
+                PrivilegeConstants.JCR_WORKSPACE_MANAGEMENT)
+            .forEach(privilege -> {
+                assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, privilege,
+                        true, jsonValue -> {
+                            assertNotNull(jsonValue);
+                            assertEquals(JsonValue.TRUE, jsonValue);
+                        });
+            });
         assertPrivilege(acePrivleges, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_REMOVE_NODE,
                 true, jsonValue -> {
                     assertNotNull(jsonValue);

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
@@ -834,12 +834,12 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
             assertTrue(jsonValue instanceof JsonObject);
             JsonObject restrictionsObj = (JsonObject)jsonValue;
 
-            JsonValue repGlobValue = restrictionsObj.get("rep:glob");
+            JsonValue repGlobValue = restrictionsObj.get(AccessControlConstants.REP_GLOB);
             assertNotNull(repGlobValue);
             assertTrue(repGlobValue instanceof JsonString);
             assertEquals("/hello", ((JsonString)repGlobValue).getString());
 
-            JsonValue repItemNamesValue = restrictionsObj.get("rep:itemNames");
+            JsonValue repItemNamesValue = restrictionsObj.get(AccessControlConstants.REP_ITEM_NAMES);
             assertNotNull(repItemNamesValue);
             assertTrue(repItemNamesValue instanceof JsonArray);
             assertEquals(2, ((JsonArray)repItemNamesValue).size());
@@ -991,12 +991,12 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
             assertTrue(jsonValue instanceof JsonObject);
             JsonObject restrictionsObj = (JsonObject)jsonValue;
 
-            JsonValue repGlobValue = restrictionsObj.get("rep:glob");
+            JsonValue repGlobValue = restrictionsObj.get(AccessControlConstants.REP_GLOB);
             assertNotNull(repGlobValue);
             assertTrue(repGlobValue instanceof JsonString);
             assertEquals("/hello", ((JsonString)repGlobValue).getString());
 
-            JsonValue repItemNamesValue = restrictionsObj.get("rep:itemNames");
+            JsonValue repItemNamesValue = restrictionsObj.get(AccessControlConstants.REP_ITEM_NAMES);
             assertNotNull(repItemNamesValue);
             assertTrue(repItemNamesValue instanceof JsonArray);
             assertEquals(2, ((JsonArray)repItemNamesValue).size());
@@ -1072,7 +1072,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
             assertTrue(jsonValue instanceof JsonObject);
             JsonObject restrictionsObj = (JsonObject)jsonValue;
 
-            JsonValue repGlobValue = restrictionsObj.get("rep:glob");
+            JsonValue repGlobValue = restrictionsObj.get(AccessControlConstants.REP_GLOB);
             assertNotNull(repGlobValue);
             assertTrue(repGlobValue instanceof JsonString);
             assertEquals("/hello", ((JsonString)repGlobValue).getString());
@@ -1107,7 +1107,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
             assertTrue(jsonValue instanceof JsonObject);
             JsonObject restrictionsObj = (JsonObject)jsonValue;
 
-            JsonValue repGlobValue = restrictionsObj.get("rep:glob");
+            JsonValue repGlobValue = restrictionsObj.get(AccessControlConstants.REP_GLOB);
             assertNotNull(repGlobValue);
             assertTrue(repGlobValue instanceof JsonString);
             assertEquals("/hello_again", ((JsonString)repGlobValue).getString());
@@ -1697,10 +1697,10 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
         addOrUpdateAce(testFolderUrl, postParams);
 
         JsonObject groupPrivilegesObject = getAcePrivleges(testFolderUrl, testGroupId);
-        assertEquals(3, groupPrivilegesObject.size());
+        assertEquals(2, groupPrivilegesObject.size());
 
         //allow privilege
-        assertPrivilege(groupPrivilegesObject, true, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_READ, true, jsonValue -> assertEquals(ValueType.TRUE, jsonValue.getValueType()));
+        assertPrivilege(groupPrivilegesObject, false, PrivilegeValues.ALLOW, PrivilegeConstants.JCR_READ);
         assertPrivilege(groupPrivilegesObject, true, PrivilegeValues.ALLOW, PrivilegeConstants.REP_READ_PROPERTIES, true, jsonValue -> {
             assertNotNull(jsonValue);
             assertTrue(jsonValue instanceof JsonObject);

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalRestrictionTest.java
@@ -34,6 +34,7 @@ import javax.jcr.Value;
 import javax.jcr.ValueFactory;
 
 import org.apache.jackrabbit.oak.security.authorization.restriction.RestrictionProviderImpl;
+import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.CompositeRestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
@@ -94,11 +95,11 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testHashCode() throws Exception {
-        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
-        LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), val("/hello2"));
+        LocalRestriction lr1 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
+        LocalRestriction lr2 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello2"));
         assertNotSame(lr1.hashCode(), lr2.hashCode());
 
-        LocalRestriction lr3 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr3 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         assertEquals(lr1.hashCode(), lr3.hashCode());
     }
 
@@ -107,8 +108,8 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testGetName() throws Exception {
-        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
-        assertEquals("rep:glob", lr1.getName());
+        LocalRestriction lr1 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
+        assertEquals(AccessControlConstants.REP_GLOB, lr1.getName());
     }
 
     /**
@@ -116,10 +117,10 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testIsMultiValue() throws Exception {
-        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr1 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         assertFalse(lr1.isMultiValue());
 
-        LocalRestriction lr2 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
+        LocalRestriction lr2 = new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2"));
         assertTrue(lr2.isMultiValue());
     }
 
@@ -128,16 +129,16 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testGetValue() throws Exception {
-        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr1 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         assertEquals(val("/hello1"), lr1.getValue());
 
-        LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), (Value)null);
+        LocalRestriction lr2 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), (Value)null);
         assertNull(lr2.getValue());
 
-        LocalRestriction lr3 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
+        LocalRestriction lr3 = new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2"));
         assertEquals(val("item1"), lr3.getValue());
 
-        LocalRestriction lr4 = new LocalRestriction(rd("rep:itemNames"), (Value[])new Value[0]);
+        LocalRestriction lr4 = new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), (Value[])new Value[0]);
         assertNull(lr4.getValue());
     }
 
@@ -146,13 +147,13 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testGetValues() throws Exception {
-        LocalRestriction lr1 = new LocalRestriction(rd("rep:itemNames"), vals("item1", "item2"));
+        LocalRestriction lr1 = new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), vals("item1", "item2"));
         assertArrayEquals(vals("item1", "item2"), lr1.getValues());
 
-        LocalRestriction lr2 = new LocalRestriction(rd("rep:itemNames"), (Value[])null);
+        LocalRestriction lr2 = new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), (Value[])null);
         assertNull(lr2.getValues());
 
-        LocalRestriction lr3 = new LocalRestriction(rd("rep:itemNames"), new Value[0]);
+        LocalRestriction lr3 = new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), new Value[0]);
         assertArrayEquals(new Value[0], lr3.getValues());
     }
 
@@ -161,7 +162,7 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testToString() throws Exception {
-        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr1 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         assertNotNull(lr1.toString());
 
         LocalRestriction lr2 = new LocalRestriction(null, val("/hello1"));
@@ -173,15 +174,15 @@ public class LocalRestrictionTest {
      */
     @Test
     public void testEqualsObject() throws Exception {
-        LocalRestriction lr1 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr1 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         assertEquals(lr1, lr1);
         assertNotEquals(lr1, null);
         assertNotEquals(lr1, this);
 
-        LocalRestriction lr2 = new LocalRestriction(rd("rep:glob"), val("/hello2"));
+        LocalRestriction lr2 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello2"));
         assertNotEquals(lr1, lr2);
 
-        LocalRestriction lr3 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr3 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         assertEquals(lr1, lr3);
 
         LocalRestriction lr4 = new LocalRestriction(null, val("/hello1"));
@@ -189,19 +190,19 @@ public class LocalRestrictionTest {
         assertEquals(lr4, lr5);
 
         LocalRestriction lr6 = new LocalRestriction(null, val("/hello1"));
-        LocalRestriction lr7 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr7 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         assertNotEquals(lr6, lr7);
 
-        LocalRestriction lr8 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
+        LocalRestriction lr8 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
         LocalRestriction lr9 = new LocalRestriction(null, val("/hello1"));
         assertNotEquals(lr8, lr9);
 
-        LocalRestriction lr10 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
-        LocalRestriction lr11 = new LocalRestriction(rd("rep:itemNames"), val("/hello1"));
+        LocalRestriction lr10 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
+        LocalRestriction lr11 = new LocalRestriction(rd(AccessControlConstants.REP_ITEM_NAMES), val("/hello1"));
         assertNotEquals(lr10, lr11);
 
-        LocalRestriction lr12 = new LocalRestriction(rd("rep:glob"), val("/hello1"));
-        LocalRestriction lr13 = new LocalRestriction(rd("rep:glob"), val("/hello2"));
+        LocalRestriction lr12 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello1"));
+        LocalRestriction lr13 = new LocalRestriction(rd(AccessControlConstants.REP_GLOB), val("/hello2"));
         assertNotEquals(lr12, lr13);
     }
 


### PR DESCRIPTION
If any leaf privilege has different restrictions than a contained aggregate parent privilege, then the parent should not be set and the non-conflicting ancestors should be set instead to avoid an ambiguous definition.

For example, consider rep:write being allowed and then the leaf rep:removeProperties is also allowed but with restrictions with something like this:

```
curl -FprincipalId=slingshot1 \
	-Fprivilege@rep:write=allow \
	-Fprivilege@rep:removeProperties=allow \
	-Frestriction@rep:removeProperties@rep:glob@Allow=/hello \
	http://admin:admin@localhost:8080/starter.modifyAce.html
```

Expected that rep:write would not be marked as allowed, but the non-conflicting items in the rep:write aggregate privilege would be allowed.
