### PR TITLE
SLING-12022 Fix test compatibility with java 17

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -1,8 +1,0 @@
-{
-  "jenkins": {
-    "jdks": [
-      17
-    ],
-    "operatingSystems": ["linux"]
-  }
-}

--- a/.sling-module.json
+++ b/.sling-module.json
@@ -1,8 +1,8 @@
 {
   "jenkins": {
     "jdks": [
-      11,
-      8
-    ]
+      17
+    ],
+    "operatingSystems": ["linux"]
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <!-- To debug the pax process, override this with -D -->
         <pax.vm.options>-Xmx512M</pax.vm.options>
+
+        <oak.version>1.44.0</oak.version>
     </properties>
 
     <build>
@@ -83,16 +85,10 @@
                 </executions>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <systemProperties>
-                        <property>
-                            <name>bundle.filename</name>
-                            <value>${basedir}/target/${project.build.finalName}.jar</value>
-                        </property>
-                        <property>
-                            <name>pax.vm.options</name>
-                            <value>${pax.vm.options}</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <bundle.filename>${basedir}/target/${project.build.finalName}.jar</bundle.filename>
+                        <pax.vm.options>${pax.vm.options}</pax.vm.options>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
@@ -123,8 +119,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-api</artifactId>
-            <version>2.18.2</version>
+            <artifactId>oak-jackrabbit-api</artifactId>
+            <version>${oak.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -147,7 +143,7 @@
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-security-spi</artifactId>
-            <version>1.8.0</version>
+            <version>${oak.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -189,14 +185,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>2.3.4</version>
+            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+            <version>3.1.10-1.44.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-            <version>2.1.2</version>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+            <version>3.4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -232,7 +228,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.paxexam</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -274,7 +270,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>7.0.0</version>
+            <version>7.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/JsonConvertTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/JsonConvertTest.java
@@ -200,8 +200,6 @@ public class JsonConvertTest {
      */
     @Test
     public void testAddToJsonObjectBuilderStringObject() throws RepositoryException {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
-
         String key = JsonConvert.KEY_ALLOW;
         Function<JsonObject, Object> doubleFn = json -> json.getJsonNumber(key).doubleValue();
         Function<JsonObject, Object> bigDecimalFn = json -> json.getJsonNumber(key).bigDecimalValue();
@@ -239,6 +237,7 @@ public class JsonConvertTest {
         };
         for (Object[] objects : candidates) {
             Object value = objects[1];
+            JsonObjectBuilder builder = Json.createObjectBuilder();
             JsonConvert.addTo(builder, key, value);
             JsonObject build = builder.build();
             assertNotNull(build);
@@ -259,8 +258,6 @@ public class JsonConvertTest {
      */
     @Test
     public void testAddToJsonArrayBuilderObject() {
-        JsonArrayBuilder builder = Json.createArrayBuilder();
-
         Function<JsonArray, Object> doubleFn = json -> json.getJsonNumber(0).doubleValue();
         Function<JsonArray, Object> bigDecimalFn = json -> json.getJsonNumber(0).bigDecimalValue();
         Function<JsonArray, Object> bigIntegerFn = json -> json.getJsonNumber(0).bigIntegerValue();
@@ -295,6 +292,7 @@ public class JsonConvertTest {
         };
         for (Object[] objects : candidates) {
             Object value = objects[1];
+            JsonArrayBuilder builder = Json.createArrayBuilder();
             JsonConvert.addTo(builder, value);
             JsonArray build = builder.build();
             assertNotNull(build);

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
@@ -18,8 +18,10 @@
  */
 package org.apache.sling.jcr.jackrabbit.accessmanager.it;
 
+import static org.apache.sling.testing.paxexam.SlingOptions.slingBundleresource;
 import static org.apache.sling.testing.paxexam.SlingOptions.slingCommonsCompiler;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingJcrJackrabbitSecurity;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingJcrJackrabbitAccessmanager;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingJcrJackrabbitUsermanager;
 import static org.apache.sling.testing.paxexam.SlingOptions.slingScriptingJavascript;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -121,8 +123,10 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
         final Option bundle = buildBundleResourcesBundle();
 
         return new Option[]{
+            slingBundleresource(),
             // for usermanager support
-            slingJcrJackrabbitSecurity(),
+            slingJcrJackrabbitAccessmanager(),
+            slingJcrJackrabbitUsermanager(),
             // add javascript support for the test script
             slingCommonsCompiler(),
             when(bundle != null).useOptions(slingScriptingJavascript()),

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerTestSupport.java
@@ -76,63 +76,32 @@ public abstract class AccessManagerTestSupport extends TestSupport {
             vmOption = new VMOption(vmOpt);
         }
 
-        final String jacocoOpt = System.getProperty("jacoco.command");
-        VMOption jacocoCommand = null;
-        if (jacocoOpt != null && !jacocoOpt.isEmpty()) {
-            jacocoCommand = new VMOption(jacocoOpt);
-        }
-
-        // switch to the minimum oak version that supports principalbased access control
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-api", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob-plugins", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-commons", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-core", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-core-spi", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-jcr", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-lucene", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-query-spi", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-security-spi", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-segment-tar", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-composite", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-document", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-spi", "1.18.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-jackrabbit-api", "1.18.0");
-        versionResolver.setVersion("commons-codec", "commons-codec", "1.14");
-        versionResolver.setVersion("org.apache.tika", "tika-core", "1.24");
-        versionResolver.setVersion("org.apache.tika", "tika-parsers", "1.24");
-
         // newer version of sling.api and dependencies for SLING-10034
         //   may remove at a later date if the superclass includes these versions or later
-        versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.api");
-        versionResolver.setVersion("org.apache.sling", "org.apache.sling.resourceresolver", "1.7.0"); // to be compatible with current o.a.sling.api
-        versionResolver.setVersion("org.apache.sling", "org.apache.sling.scripting.core", "2.3.4"); // to be compatible with current o.a.sling.api
-        versionResolver.setVersion("org.apache.sling", "org.apache.sling.scripting.api", "2.2.0"); // to be compatible with current o.a.sling.api
-        versionResolver.setVersion("org.apache.sling", "org.apache.sling.servlets.resolver", "2.7.12"); // to be compatible with current o.a.sling.api
-        versionResolver.setVersion("org.apache.sling", "org.apache.sling.commons.compiler", "2.4.0"); // to be compatible with current o.a.sling.scripting.core
+        versionResolver.setVersion("org.apache.sling", "org.apache.sling.api", "2.27.2");
+        versionResolver.setVersion("org.apache.sling", "org.apache.sling.engine", "2.15.6");
+        versionResolver.setVersion("org.apache.sling", "org.apache.sling.resourceresolver", "1.10.0");
+        versionResolver.setVersion("org.apache.sling", "org.apache.sling.servlets.resolver", "2.9.14");
+
+        // workaround for FELIX-6656 - use jetty 4.x version instead of the 5.x version
+        //  may remove at a later date after http.jetty-5.1.2 is released and used
+        versionResolver.setVersion("org.apache.felix", "org.apache.felix.http.jetty", "4.2.0");
+        versionResolver.setVersion("org.apache.felix", "org.apache.felix.http.servlet-api", "2.0.0");
 
         return options(
             composite(
                 super.baseConfiguration(),
                 when(vmOption != null).useOptions(vmOption),
-                when(jacocoCommand != null).useOptions(jacocoCommand),
                 optionalRemoteDebug(),
                 slingQuickstart(),
                 testBundle("bundle.filename"),
                 junitBundles(),
                 awaitility()
             ).add(
-                // needed by latest version of org.apache.sling.api
-                mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.converter").version("1.0.14"),
-                // switch to the oak variation of jackrabbit-api
-                mavenBundle().groupId("org.apache.jackrabbit").artifactId("oak-jackrabbit-api").version(versionResolver)
-            ).add(
                 additionalOptions()
             ).remove(
                 // remove our bundle under test to avoid duplication
-                mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.jcr.jackrabbit.accessmanager").version(versionResolver),
-                // switch to the oak variation of jackrabbit-api
-                mavenBundle().groupId("org.apache.jackrabbit").artifactId("jackrabbit-api").version(versionResolver)
+                mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.jcr.jackrabbit.accessmanager").version(versionResolver)
             )
         );
     }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
@@ -288,8 +288,14 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
         testFolderUrl = createTestFolder(null, "sling-tests2",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true, \"childPropTwo\" : \"two\" } }");
 
-        //1. create an initial set of privileges
-        List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
+        //0. ensure everyone has the privilege to read the test nodes
+        List<NameValuePair> postParams = new AcePostParamsBuilder("everyone")
+                .withPrivilege(PrivilegeConstants.REP_READ_NODES, PrivilegeValues.ALLOW)
+                .build();
+        addOrUpdateAce(testFolderUrl, postParams);
+
+        //1. create an initial set of privileges for the test user
+        postParams = new AcePostParamsBuilder(testUserId)
                 .withPrivilege(PrivilegeConstants.REP_READ_PROPERTIES, PrivilegeValues.DENY)
                 .withPrivilegeRestriction(PrivilegeValues.ALLOW, PrivilegeConstants.REP_READ_PROPERTIES, AccessControlConstants.REP_ITEM_NAMES, "childPropOne")
                 .build();

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/PrincipalAceTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/PrincipalAceTestSupport.java
@@ -44,7 +44,7 @@ public abstract class PrincipalAceTestSupport extends AccessManagerClientTestSup
     @Override
     protected Option[] additionalOptions() throws IOException {
         return composite(super.additionalOptions())
-           .add(mavenBundle().groupId("org.apache.jackrabbit").artifactId("oak-authorization-principalbased").version("1.18.0"),
+           .add(mavenBundle().groupId("org.apache.jackrabbit").artifactId("oak-authorization-principalbased").version("1.48.0"),
                 newConfiguration("org.apache.jackrabbit.oak.spi.security.authorization.principalbased.impl.PrincipalBasedAuthorizationConfiguration")
                     .put("enableAggregationFilter", true)
                     .asOption(),


### PR DESCRIPTION
Some of the tests are failing when building with java 17.  Bump of some dependencies to later versions and other refactoring.