### PR TITLE
SLING-12105 Bump dependencies to the earliest versions without known vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.23.4</version>
+            <version>2.25.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.base</artifactId>
-            <version>3.0.6</version>
+            <version>3.1.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Mostly to keep tooling from flagging these as "vulnerabilities from dependencies"

1. bump org.apache.sling.api to 2.25.4
2. bump org.apache.sling.jcr.base to 3.1.12