### PR TITLE
SLING-12224 Remove dependency on org.apache.sling.jcr.base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.jcr.base</artifactId>
-            <version>3.1.12</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-security-spi</artifactId>
             <version>${oak.version}</version>

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/PrivilegesInfo.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/PrivilegesInfo.java
@@ -42,11 +42,11 @@ import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import jakarta.json.JsonValue.ValueType;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.JsonConvert;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -81,7 +81,7 @@ public class PrivilegesInfo {
      * @throws RepositoryException if any errors reading the information
      */
     public Privilege [] getSupportedPrivileges(Session session, String absPath) throws RepositoryException {
-        AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+        AccessControlManager accessControlManager = session.getAccessControlManager();
         return accessControlManager.getSupportedPrivileges(absPath);
     }
 
@@ -193,7 +193,7 @@ public class PrivilegesInfo {
 
         Map<Principal, AccessRights> map;
         AccessControlManager acm = session.getAccessControlManager();
-        PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+        PrincipalManager principalManager = ((JackrabbitSession)session).getPrincipalManager();
         Function<? super JsonValue, ? extends Principal> keyMapper = val -> {
             String principalId = ((JsonObject)val).getString(JsonConvert.KEY_PRINCIPAL);
             return principalManager.getPrincipal(principalId);
@@ -256,7 +256,7 @@ public class PrivilegesInfo {
      */
     public AccessRights getDeclaredAccessRightsForPrincipal(Session session, String absPath, String principalId) throws RepositoryException {
         Map<Principal, AccessRights> declaredAccessRights = getDeclaredAccessRights(session, absPath);
-        PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+        PrincipalManager principalManager = ((JackrabbitSession)session).getPrincipalManager();
         Principal principal = principalManager.getPrincipal(principalId);
         return declaredAccessRights.get(principal);
     }
@@ -414,7 +414,7 @@ public class PrivilegesInfo {
      */
     public AccessRights getEffectiveAccessRightsForPrincipal(Session session, String absPath, String principalId) throws RepositoryException {
         Map<Principal, AccessRights> effectiveAccessRights = getEffectiveAccessRights(session, absPath);
-        PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+        PrincipalManager principalManager = ((JackrabbitSession)session).getPrincipalManager();
         Principal principal = principalManager.getPrincipal(principalId);
         return effectiveAccessRights.get(principal);
     }
@@ -444,7 +444,7 @@ public class PrivilegesInfo {
      */
     public boolean canAddChildren(Session session, String absPath) {
         try {
-            AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+            AccessControlManager accessControlManager = session.getAccessControlManager();
             return accessControlManager.hasPrivileges(absPath, new Privilege[] {
                             accessControlManager.privilegeFromName(Privilege.JCR_ADD_CHILD_NODES)
                         });
@@ -478,8 +478,7 @@ public class PrivilegesInfo {
      */
     public boolean canDeleteChildren(Session session, String absPath) {
         try {
-            AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
-            
+            AccessControlManager accessControlManager = session.getAccessControlManager();
             return accessControlManager.hasPrivileges(absPath, new Privilege[] {
                             accessControlManager.privilegeFromName(Privilege.JCR_REMOVE_CHILD_NODES)
                         });
@@ -513,7 +512,7 @@ public class PrivilegesInfo {
      */
     public boolean canDelete(Session session, String absPath) {
         try {
-            AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+            AccessControlManager accessControlManager = session.getAccessControlManager();
 
             String parentPath;
             int lastSlash = absPath.lastIndexOf('/');
@@ -557,7 +556,7 @@ public class PrivilegesInfo {
      */
     public boolean canModifyProperties(Session session, String absPath) {
         try {
-            AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+            AccessControlManager accessControlManager = session.getAccessControlManager();
             return accessControlManager.hasPrivileges(absPath, new Privilege[] {
                             accessControlManager.privilegeFromName(Privilege.JCR_MODIFY_PROPERTIES)
                         });
@@ -591,7 +590,7 @@ public class PrivilegesInfo {
      */
     public boolean canReadAccessControl(Session session, String absPath) {
         try {
-            AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+            AccessControlManager accessControlManager = session.getAccessControlManager();
             return accessControlManager.hasPrivileges(absPath, new Privilege[] {
                             accessControlManager.privilegeFromName(Privilege.JCR_READ_ACCESS_CONTROL)
                         });
@@ -625,7 +624,7 @@ public class PrivilegesInfo {
      */
     public boolean canModifyAccessControl(Session session, String absPath) {
         try {
-            AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+            AccessControlManager accessControlManager = session.getAccessControlManager();
             return accessControlManager.hasPrivileges(absPath, new Privilege[] {
                             accessControlManager.privilegeFromName(Privilege.JCR_MODIFY_ACCESS_CONTROL)
                         });

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractAccessGetServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractAccessGetServlet.java
@@ -39,12 +39,10 @@ import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.Privilege;
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.stream.JsonGenerator;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
 import org.apache.jackrabbit.api.security.authorization.PrincipalAccessControlList;
@@ -53,13 +51,16 @@ import org.apache.jackrabbit.oak.spi.security.authorization.restriction.Restrict
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ResourceNotFoundException;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrincipalAceHelper;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrivilegesHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.stream.JsonGenerator;
 
 @SuppressWarnings("serial")
 public abstract class AbstractAccessGetServlet extends AbstractAccessServlet {
@@ -133,7 +134,7 @@ public abstract class AbstractAccessGetServlet extends AbstractAccessServlet {
         }
 
         // validate that the submitted name is valid
-        PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(jcrSession);
+        PrincipalManager principalManager = ((JackrabbitSession)jcrSession).getPrincipalManager();
         Principal principal = principalManager.getPrincipal(principalId);
         if (principal == null) {
             throw new RepositoryException("Invalid principalId was submitted.");

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAceServlet.java
@@ -27,17 +27,17 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.sling.api.resource.ResourceNotFoundException;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.JsonConvert;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrivilegesHelper;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 @SuppressWarnings({"serial", "java:S110"})
 public abstract class AbstractGetAceServlet extends AbstractAccessGetServlet {
@@ -77,7 +77,7 @@ public abstract class AbstractGetAceServlet extends AbstractAccessGetServlet {
         }
 
         // combine any aggregates that are still valid
-        AccessControlManager acm = AccessControlUtil.getAccessControlManager(jcrSession);
+        AccessControlManager acm = jcrSession.getAccessControlManager();
         Map<Privilege, Integer> privilegeLongestDepthMap = PrivilegesHelper.buildPrivilegeLongestDepthMap(acm.privilegeFromName(PrivilegeConstants.JCR_ALL));
         PrivilegesHelper.consolidateAggregates(jcrSession, resourcePath, privilegeToLocalPrivilegesMap, privilegeLongestDepthMap);
 

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
@@ -38,7 +38,6 @@ import jakarta.json.JsonObjectBuilder;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.JsonConvert;
@@ -103,7 +102,7 @@ public abstract class AbstractGetAclServlet extends AbstractAccessGetServlet {
         }
 
         // combine any aggregates that are still valid
-        AccessControlManager acm = AccessControlUtil.getAccessControlManager(jcrSession);
+        AccessControlManager acm = jcrSession.getAccessControlManager();
         Map<Privilege, Integer> privilegeLongestDepthMap = PrivilegesHelper.buildPrivilegeLongestDepthMap(acm.privilegeFromName(PrivilegeConstants.JCR_ALL));
         for (Entry<Principal, Map<Privilege, LocalPrivilege>> entry : principalToPrivilegesMap.entrySet()) {
             Map<Privilege, LocalPrivilege> privilegeToLocalPrivilegesMap = entry.getValue();

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeleteAcesServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeleteAcesServlet.java
@@ -29,9 +29,9 @@ import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.DeleteAces;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostResponse;
@@ -144,7 +144,7 @@ public class DeleteAcesServlet extends AbstractAccessPostServlet implements Dele
         validateResourcePath(jcrSession, resourcePath);
 
         // validate that the submitted names are valid
-        PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(jcrSession);
+        PrincipalManager principalManager = ((JackrabbitSession)jcrSession).getPrincipalManager();
         for (String pid : principalNamesToDelete) {
             Principal principal = principalManager.getPrincipal(pid);
             if (principal == null) {
@@ -165,7 +165,7 @@ public class DeleteAcesServlet extends AbstractAccessPostServlet implements Dele
         @NotNull
         Set<Principal> found = validateArgs(jcrSession, resourcePath, principalNamesToDelete);
         try {
-            AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(jcrSession);
+            AccessControlManager accessControlManager = jcrSession.getAccessControlManager();
             AccessControlList updatedAcl = getAccessControlListOrNull(accessControlManager, resourcePath, false);
 
             // if there is no AccessControlList, then there is nothing to be deleted

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeletePrincipalAcesServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeletePrincipalAcesServlet.java
@@ -31,7 +31,6 @@ import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
 import org.apache.jackrabbit.api.security.authorization.PrincipalAccessControlList;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.DeletePrincipalAces;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrincipalAceHelper;
 import org.apache.sling.servlets.post.Modification;
@@ -117,7 +116,7 @@ public class DeletePrincipalAcesServlet extends DeleteAcesServlet implements Del
         @NotNull
         Set<Principal> found = validateArgs(jcrSession, resourcePath, principalNamesToDelete);
         try {
-            JackrabbitAccessControlManager jacm = (JackrabbitAccessControlManager)AccessControlUtil.getAccessControlManager(jcrSession);
+            JackrabbitAccessControlManager jacm = (JackrabbitAccessControlManager)jcrSession.getAccessControlManager();
 
             // track which of the submitted principals had an ACE removed
             Set<Principal> removedPrincipalSet = new HashSet<>();

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAceServlet.java
@@ -33,7 +33,6 @@ import jakarta.json.JsonObjectBuilder;
 import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetEffectiveAce;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.JsonConvert;
 import org.osgi.service.component.annotations.Component;
@@ -112,7 +111,7 @@ public class GetEffectiveAceServlet extends AbstractGetAceServlet implements Get
     @Override
     protected Map<String, List<AccessControlEntry>> getAccessControlEntriesMap(Session session, String absPath,
             Principal principal, Map<Principal, Map<DeclarationType, Set<String>>> declaredAtPaths) throws RepositoryException {
-        AccessControlManager acMgr = AccessControlUtil.getAccessControlManager(session);
+        AccessControlManager acMgr = session.getAccessControlManager();
         AccessControlPolicy[] policies = acMgr.getEffectivePolicies(absPath);
         return entriesSortedByEffectivePath(policies, ace -> principal.equals(ace.getPrincipal()), declaredAtPaths);
     }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyAceServlet.java
@@ -48,6 +48,7 @@ import javax.jcr.security.AccessControlPolicyIterator;
 import javax.jcr.security.Privilege;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
 import org.apache.jackrabbit.api.security.authorization.PrincipalAccessControlList;
@@ -56,7 +57,6 @@ import org.apache.jackrabbit.oak.spi.security.authorization.restriction.Restrict
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.jcr.jackrabbit.accessmanager.ModifyAce;
@@ -228,7 +228,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
         // Calculate a map of restriction names to the restriction definition.
         // Use for fast lookup during the calls below.
         Map<String, RestrictionDefinition> srMap = buildRestrictionNameToDefinitionMap(resourcePath);
-        AccessControlManager acm = AccessControlUtil.getAccessControlManager(session);
+        AccessControlManager acm = session.getAccessControlManager();
         Map<Privilege, Integer> privilegeLongestDepthMap = PrivilegesHelper.buildPrivilegeLongestDepthMap(acm.privilegeFromName(PrivilegeConstants.JCR_ALL));
 
         // first calculate what is currently stored in the ace
@@ -268,7 +268,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
         }
 
         // validate that the submitted name is valid
-        PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(jcrSession);
+        PrincipalManager principalManager = ((JackrabbitSession)jcrSession).getPrincipalManager();
         Principal principal = principalManager.getPrincipal(principalId);
         if (principal == null) {
             throw new RepositoryException("Invalid principalId was submitted.");
@@ -276,7 +276,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
 
         validateResourcePath(jcrSession, resourcePath);
 
-        AccessControlManager acm = AccessControlUtil.getAccessControlManager(jcrSession);
+        AccessControlManager acm = jcrSession.getAccessControlManager();
         JackrabbitAccessControlList acl = getAcl(acm, resourcePath, principal);
         if (acl == null) {
             throw new IllegalStateException("No access control list is available so unable to process");
@@ -1020,7 +1020,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
 
         // Calculate a map of restriction names to the restriction definition.
         // Use for fast lookup during the calls below.
-        AccessControlManager acm = AccessControlUtil.getAccessControlManager(jcrSession);
+        AccessControlManager acm = jcrSession.getAccessControlManager();
         Map<String, RestrictionDefinition> srMap = buildRestrictionNameToDefinitionMap(resourcePath);
         Map<Privilege, Integer> privilegeLongestDepthMap = PrivilegesHelper.buildPrivilegeLongestDepthMap(acm.privilegeFromName(PrivilegeConstants.JCR_ALL));
 
@@ -1137,7 +1137,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
 
         try {
             // Get or create the ACL for the node.
-            AccessControlManager acm = AccessControlUtil.getAccessControlManager(jcrSession);
+            AccessControlManager acm = jcrSession.getAccessControlManager();
             JackrabbitAccessControlList acl = getAcl(acm, resourcePath, principal);
 
             // remove all the old aces for the principal

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/JsonConvertTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/JsonConvertTest.java
@@ -52,7 +52,6 @@ import org.apache.jackrabbit.oak.spi.security.authorization.restriction.Restrict
 import org.apache.jackrabbit.oak.spi.security.principal.PrincipalImpl;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -78,7 +77,7 @@ public class JsonConvertTest {
     public void buildPrivilegesMap() throws RepositoryException {
         context.registerService(new RestrictionProviderImpl());
         Session session = context.resourceResolver().adaptTo(Session.class);
-        acm = AccessControlUtil.getAccessControlManager(session);
+        acm = session.getAccessControlManager();
     }
 
     private Privilege priv(String privilegeName) throws RepositoryException {

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelperTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrivilegesHelperTest.java
@@ -47,7 +47,6 @@ import org.apache.jackrabbit.oak.spi.security.authorization.restriction.Restrict
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -72,7 +71,7 @@ public class PrivilegesHelperTest {
     public void buildPrivilegesMap() throws RepositoryException {
         context.registerService(new RestrictionProviderImpl());
         Session session = context.resourceResolver().adaptTo(Session.class);
-        acm = AccessControlUtil.getAccessControlManager(session);
+        acm = session.getAccessControlManager();
         Privilege jcrAll = acm.privilegeFromName(PrivilegeConstants.JCR_ALL);
         privilegeLongestDepthMap = PrivilegesHelper.buildPrivilegeLongestDepthMap(jcrAll);
     }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/LocalPrivilegeTest.java
@@ -42,7 +42,6 @@ import org.apache.jackrabbit.oak.spi.security.authorization.restriction.Restrict
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -66,7 +65,7 @@ public class LocalPrivilegeTest {
     @Before
     public void setup() throws RepositoryException {
         Session session = context.resourceResolver().adaptTo(Session.class);
-        acm = AccessControlUtil.getAccessControlManager(session);
+        acm = session.getAccessControlManager();
         context.registerService(new RestrictionProviderImpl());
     }
 


### PR DESCRIPTION
Remove dependency on org.apache.sling.jcr.base since it is only used for AccessControlUtil methods to access the UserManager and PrincipalManager. 

Since this bundle is a jackrabbit/oak specific implementation we can use the JackrabbitSession methods to accomplish the same without the dependency.