### PR TITLE
SLING-12868 migrate to Sling API 3.x and Jakarta Servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.jcr.jackrabbit.accessmanager</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>Apache Sling JCR Jackrabbit Access Manager</name>
     <description>
         Provides POST operations for JCR Jackrabbit Access Management
@@ -42,13 +42,14 @@
     </scm>
 
     <properties>
-        <sling.java.version>8</sling.java.version>
+        <sling.java.version>17</sling.java.version>
         <project.build.outputTimestamp>2024-01-08T23:41:57Z</project.build.outputTimestamp>
-        <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
+        <org.ops4j.pax.exam.version>4.14.0</org.ops4j.pax.exam.version>
         <!-- To debug the pax process, override this with -D -->
         <pax.vm.options>-Xmx512M</pax.vm.options>
 
         <oak.version>1.44.0</oak.version>
+        <slf4j.version>2.0.17</slf4j.version>
     </properties>
 
     <build>
@@ -105,6 +106,11 @@
             <artifactId>org.osgi.annotation.versioning</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -112,9 +118,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.25.4</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -126,7 +138,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.servlets.post</artifactId>
-            <version>2.3.22</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -143,6 +155,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -186,13 +199,19 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-            <version>3.1.10-1.44.0</version>
+            <version>4.0.0-1.62.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>3.4.12</version>
+            <version>3.5.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.paxexam</artifactId>
+            <version>4.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -226,12 +245,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.paxexam</artifactId>
-            <version>4.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>4.4.13</version>
@@ -259,7 +272,7 @@
        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.0</version>
+            <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -277,6 +290,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrincipalAceHelper.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/impl/PrincipalAceHelper.java
@@ -19,7 +19,7 @@ package org.apache.sling.jcr.jackrabbit.accessmanager.impl;
 import javax.jcr.security.AccessControlEntry;
 
 import org.apache.jackrabbit.api.security.authorization.PrincipalAccessControlList;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.request.RequestPathInfo;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.jetbrains.annotations.NotNull;
@@ -42,7 +42,7 @@ public class PrincipalAceHelper {
      * @param request the current request
      * @return the effect path
      */
-    public static String getEffectivePath(SlingHttpServletRequest request) {
+    public static String getEffectivePath(SlingJakartaHttpServletRequest request) {
         String effectivePath = request.getResource().getPath();
         if (ResourceUtil.isNonExistingResource(request.getResource())) {
             // for non-existing resource trim the selectors and extension 

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/package-info.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("4.0.0")
+@org.osgi.annotation.versioning.Version("5.0.0")
 package org.apache.sling.jcr.jackrabbit.accessmanager;
 
 

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractAccessGetServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractAccessGetServlet.java
@@ -39,8 +39,6 @@ import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.Privilege;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
@@ -48,8 +46,8 @@ import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
 import org.apache.jackrabbit.api.security.authorization.PrincipalAccessControlList;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.ResourceNotFoundException;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
@@ -61,16 +59,18 @@ import org.jetbrains.annotations.Nullable;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.stream.JsonGenerator;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("serial")
 public abstract class AbstractAccessGetServlet extends AbstractAccessServlet {
 
     /* (non-Javadoc)
-     * @see org.apache.sling.api.servlets.SlingSafeMethodsServlet#doGet(org.apache.sling.api.SlingHttpServletRequest, org.apache.sling.api.SlingHttpServletResponse)
+     * @see org.apache.sling.api.servlets.SlingJakartaSafeMethodsServlet#doGet(org.apache.sling.api.SlingJakartaHttpServletRequest, org.apache.sling.api.SlingJakartaHttpServletResponse)
      */
     @Override
-    protected void doGet(SlingHttpServletRequest request,
-            SlingHttpServletResponse response) throws ServletException,
+    protected void doGet(SlingJakartaHttpServletRequest request,
+            SlingJakartaHttpServletResponse response) throws ServletException,
             IOException {
 
         try {
@@ -112,7 +112,7 @@ public abstract class AbstractAccessGetServlet extends AbstractAccessServlet {
     /**
      * Return the path where the action should be applied
      */
-    protected @Nullable String getItemPath(SlingHttpServletRequest request) {
+    protected @Nullable String getItemPath(SlingJakartaHttpServletRequest request) {
         return request.getResource().getPath();
     }
 

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractAccessServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractAccessServlet.java
@@ -21,12 +21,12 @@ import java.util.Set;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.CompositeRestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
-import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.api.servlets.SlingJakartaAllMethodsServlet;
 
 /**
  * Base class for all the servlets for the AccessManager operations
  */
-public abstract class AbstractAccessServlet extends SlingAllMethodsServlet {
+public abstract class AbstractAccessServlet extends SlingJakartaAllMethodsServlet {
     private static final long serialVersionUID = 6615497265938616188L;
 
     private transient RestrictionProvider compositeRestrictionProvider = null;

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAceServlet.java
@@ -102,13 +102,4 @@ public abstract class AbstractGetAceServlet extends AbstractAccessGetServlet {
     protected abstract Map<String, List<AccessControlEntry>> getAccessControlEntriesMap(Session session, String absPath, Principal principal,
             Map<Principal, Map<DeclarationType, Set<String>>> declaredAtPaths) throws RepositoryException;
 
-    /**
-     * @deprecated use {@link #getAccessControlEntriesMap(Session, String, Principal, Map)} instead
-     */
-    @Deprecated
-    protected AccessControlEntry[] getAccessControlEntries(Session session, String absPath, Principal principal) throws RepositoryException {
-        return getAccessControlEntriesMap(session, absPath, principal, new HashMap<>()).values().stream()
-            .toArray(size -> new AccessControlEntry[size]);
-    }
-
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/AbstractGetAclServlet.java
@@ -30,38 +30,20 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
-import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
-import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.JsonConvert;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrivilegesHelper;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
 @SuppressWarnings({"serial", "java:S110"})
 public abstract class AbstractGetAclServlet extends AbstractAccessGetServlet {
-
-    /**
-     * @deprecated since 3.0.12, To be removed when the exported package version goes to 4.0
-     *      use {@link JsonConvert#KEY_ORDER} instead
-     */
-    @Deprecated
-    protected static final String KEY_ORDER = JsonConvert.KEY_ORDER;
-    /**
-     * @deprecated since 3.0.12, To be removed when the exported package version goes to 4.0
-     */
-    @Deprecated
-    protected static final String KEY_DENIED = "denied";
-    /**
-     * @deprecated since 3.0.12, To be removed when the exported package version goes to 4.0
-     */
-    @Deprecated
-    protected static final String KEY_GRANTED = "granted";
 
     @Override
     protected JsonObject internalJson(Session session, String resourcePath, String principalId) throws RepositoryException {
@@ -85,8 +67,7 @@ public abstract class AbstractGetAclServlet extends AbstractAccessGetServlet {
         for (Entry<String, List<AccessControlEntry>> entry : effectivePathToEntriesMap.entrySet()) {
             List<AccessControlEntry> accessControlEntries = entry.getValue();
             for (AccessControlEntry accessControlEntry : accessControlEntries) {
-                if (accessControlEntry instanceof JackrabbitAccessControlEntry) {
-                    JackrabbitAccessControlEntry jrAccessControlEntry = (JackrabbitAccessControlEntry)accessControlEntry;
+                if (accessControlEntry instanceof JackrabbitAccessControlEntry jrAccessControlEntry) {
                     Privilege[] privileges = jrAccessControlEntry.getPrivileges();
                     if (privileges != null) {
                         Principal principal = accessControlEntry.getPrincipal();
@@ -145,40 +126,7 @@ public abstract class AbstractGetAclServlet extends AbstractAccessGetServlet {
     }
 
 
-    /**
-     * @deprecated use {@link JsonConvert#addRestrictions(JsonObjectBuilder, String, Set)} instead
-     */
-    @Deprecated
-    protected void addRestrictions(JsonObjectBuilder privilegeObj, String key, Set<LocalRestriction> restrictions) {
-        JsonConvert.addRestrictions(privilegeObj, key, restrictions);
-    }
-
-    /**
-     * @deprecated use {@link JsonConvert#addTo(javax.json.JsonArrayBuilder, Object)} instead
-     */
-    @Deprecated
-    protected JsonObjectBuilder addTo(JsonObjectBuilder builder, String key, Object value) {
-        return JsonConvert.addTo(builder, key, value);
-    }
-
-    /**
-     * @deprecated use {@link JsonConvert#addTo(JsonObjectBuilder, String, Object)} instead
-     */
-    @Deprecated
-    protected JsonArrayBuilder addTo(JsonArrayBuilder builder, Object value) {
-        return JsonConvert.addTo(builder, value);
-    }
-
     protected abstract Map<String, List<AccessControlEntry>> getAccessControlEntriesMap(Session session, String absPath,
             Map<Principal, Map<DeclarationType, Set<String>>> declaredAtPaths) throws RepositoryException;
-
-    /**
-     * @deprecated use {@link #getAccessControlEntriesMap(Session, String, Map)} instead
-     */
-    @Deprecated
-    protected AccessControlEntry[] getAccessControlEntries(Session session, String absPath) throws RepositoryException {
-        return getAccessControlEntriesMap(session, absPath, new HashMap<>()).values().stream()
-                .toArray(size -> new AccessControlEntry[size]);
-    }
 
 }

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeleteAcesServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeleteAcesServlet.java
@@ -27,15 +27,15 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
-import javax.servlet.Servlet;
+import jakarta.servlet.Servlet;
 
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.jcr.jackrabbit.accessmanager.DeleteAces;
 import org.apache.sling.servlets.post.Modification;
-import org.apache.sling.servlets.post.PostResponse;
-import org.apache.sling.servlets.post.PostResponseCreator;
+import org.apache.sling.servlets.post.JakartaPostResponse;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 import org.apache.sling.servlets.post.SlingPostConstants;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
@@ -90,7 +90,7 @@ import org.slf4j.LoggerFactory;
                     bind = "bindPostResponseCreator",
                     cardinality = ReferenceCardinality.MULTIPLE,
                     policyOption = ReferencePolicyOption.GREEDY,
-                    service = PostResponseCreator.class)
+                    service = JakartaPostResponseCreator.class)
     })
 @SuppressWarnings("java:S110")
 public class DeleteAcesServlet extends AbstractAccessPostServlet implements DeleteAces {
@@ -102,11 +102,11 @@ public class DeleteAcesServlet extends AbstractAccessPostServlet implements Dele
     private final transient Logger log = LoggerFactory.getLogger(getClass());
 
     /* (non-Javadoc)
-     * @see org.apache.sling.jackrabbit.accessmanager.post.AbstractAccessPostServlet#handleOperation(org.apache.sling.api.SlingHttpServletRequest, org.apache.sling.servlets.post.PostResponse, java.util.List)
+     * @see org.apache.sling.jackrabbit.accessmanager.post.AbstractAccessPostServlet#handleOperation(org.apache.sling.api.SlingJakartaHttpServletRequest, org.apache.sling.servlets.post.JakartaPostResponse, java.util.List)
      */
     @Override
-    protected void handleOperation(SlingHttpServletRequest request,
-            PostResponse htmlResponse, List<Modification> changes)
+    protected void handleOperation(SlingJakartaHttpServletRequest request,
+            JakartaPostResponse htmlResponse, List<Modification> changes)
             throws RepositoryException {
 
         Session session = request.getResourceResolver().adaptTo(Session.class);

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeletePrincipalAcesServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/DeletePrincipalAcesServlet.java
@@ -27,14 +27,13 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlPolicy;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
 import org.apache.jackrabbit.api.security.authorization.PrincipalAccessControlList;
 import org.apache.sling.jcr.jackrabbit.accessmanager.DeletePrincipalAces;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrincipalAceHelper;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 import org.apache.sling.servlets.post.Modification;
-import org.apache.sling.servlets.post.PostResponseCreator;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,6 +41,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
 
 /**
  * <p>
@@ -88,7 +89,7 @@ import org.slf4j.LoggerFactory;
                     bind = "bindPostResponseCreator",
                     cardinality = ReferenceCardinality.MULTIPLE,
                     policyOption = ReferencePolicyOption.GREEDY,
-                    service = PostResponseCreator.class)
+                    service = JakartaPostResponseCreator.class)
     })
 @SuppressWarnings("java:S110")
 public class DeletePrincipalAcesServlet extends DeleteAcesServlet implements DeletePrincipalAces {

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAceServlet.java
@@ -28,8 +28,6 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
-import jakarta.json.JsonObject;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetAce;
@@ -37,6 +35,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import jakarta.json.JsonObject;
+import jakarta.servlet.Servlet;
 
 /**
  * <p>

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetAclServlet.java
@@ -26,8 +26,6 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
-import jakarta.json.JsonObject;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetAcl;
@@ -35,6 +33,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import jakarta.json.JsonObject;
+import jakarta.servlet.Servlet;
 
 /**
  * <p>

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAceServlet.java
@@ -28,9 +28,6 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetEffectiveAce;
@@ -39,6 +36,10 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.servlet.Servlet;
 
 /**
  * <p>

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAclServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetEffectiveAclServlet.java
@@ -26,9 +26,6 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetEffectiveAcl;
@@ -37,6 +34,10 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.servlet.Servlet;
 
 /**
  * <p>

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetPrincipalAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/GetPrincipalAceServlet.java
@@ -28,15 +28,13 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
-import jakarta.json.JsonObject;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlPolicy;
 import org.apache.jackrabbit.api.security.authorization.PrincipalAccessControlList;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetPrincipalAce;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrincipalAceHelper;
 import org.jetbrains.annotations.NotNull;
@@ -45,6 +43,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import jakarta.json.JsonObject;
+import jakarta.servlet.Servlet;
 
 /**
  * <p>
@@ -99,7 +100,7 @@ public class GetPrincipalAceServlet extends AbstractGetAceServlet implements Get
     private static final long serialVersionUID = 1654062732084983394L;
 
     @Override
-    protected @Nullable String getItemPath(SlingHttpServletRequest request) {
+    protected @Nullable String getItemPath(SlingJakartaHttpServletRequest request) {
         return PrincipalAceHelper.getEffectivePath(request);
     }
 

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyAceServlet.java
@@ -46,7 +46,6 @@ import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.AccessControlPolicyIterator;
 import javax.jcr.security.Privilege;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
@@ -56,14 +55,14 @@ import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.jcr.jackrabbit.accessmanager.ModifyAce;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrivilegesHelper;
+import org.apache.sling.servlets.post.JakartaPostResponse;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 import org.apache.sling.servlets.post.Modification;
-import org.apache.sling.servlets.post.PostResponse;
-import org.apache.sling.servlets.post.PostResponseCreator;
 import org.apache.sling.servlets.post.SlingPostConstants;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -71,6 +70,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import jakarta.servlet.Servlet;
 
 /**
  * <p>
@@ -144,7 +145,7 @@ reference = {
                 bind = "bindPostResponseCreator",
                 cardinality = ReferenceCardinality.MULTIPLE,
                 policyOption = ReferencePolicyOption.GREEDY,
-                service = PostResponseCreator.class)
+                service = JakartaPostResponseCreator.class)
 })
 @SuppressWarnings("java:S110")
 public class ModifyAceServlet extends AbstractAccessPostServlet implements ModifyAce {
@@ -212,11 +213,11 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
                 SlingPostConstants.SUFFIX_DELETE));
 
     /* (non-Javadoc)
-     * @see org.apache.sling.jackrabbit.accessmanager.post.AbstractAccessPostServlet#handleOperation(org.apache.sling.api.SlingHttpServletRequest, org.apache.sling.servlets.post.PostResponse, java.util.List)
+     * @see org.apache.sling.jackrabbit.accessmanager.post.AbstractAccessPostServlet#handleOperation(org.apache.sling.api.SlingJakartaHttpServletRequest, org.apache.sling.servlets.post.JakartaPostResponse, java.util.List)
      */
     @Override
-    protected void handleOperation(SlingHttpServletRequest request,
-            PostResponse response, List<Modification> changes)
+    protected void handleOperation(SlingJakartaHttpServletRequest request,
+            JakartaPostResponse response, List<Modification> changes)
             throws RepositoryException {
         Session session = request.getResourceResolver().adaptTo(Session.class);
         String resourcePath = getItemPath(request);
@@ -365,7 +366,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
      * @param pattern the regex pattern to match
      * @return map of parameter names to Matcher that match the pattern
      */
-    protected @NotNull Map<String, Matcher> getMatchedRequestParameterNames(@NotNull SlingHttpServletRequest request, @NotNull Pattern pattern) {
+    protected @NotNull Map<String, Matcher> getMatchedRequestParameterNames(@NotNull SlingJakartaHttpServletRequest request, @NotNull Pattern pattern) {
         Map<String, Matcher> keys = new HashMap<>();
         Enumeration<String> parameterNames = request.getParameterNames();
         while (parameterNames.hasMoreElements()) {
@@ -387,7 +388,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
      * @param privilegeToLocalPrivilegesMap the map containing the declared LocalPrivilege items
      */
     protected void processPostedPrivilegeDeleteParams(@NotNull AccessControlManager acm,
-            @NotNull SlingHttpServletRequest request,
+            @NotNull SlingJakartaHttpServletRequest request,
             @NotNull Map<Privilege, LocalPrivilege> privilegeToLocalPrivilegesMap) throws RepositoryException {
         @NotNull
         Map<String, Matcher> postedPrivilegeDeleteNames = getMatchedRequestParameterNames(request, PRIVILEGE_PATTERN_DELETE);
@@ -419,7 +420,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
      * @param privilegeToLocalPrivilegesMap the map containing the declared LocalPrivilege items
      */
     protected void processPostedRestrictionDeleteParams(@NotNull AccessControlManager acm,
-            @NotNull SlingHttpServletRequest request,
+            @NotNull SlingJakartaHttpServletRequest request,
             @NotNull Map<String, RestrictionDefinition> srMap,
             @NotNull Map<Privilege, LocalPrivilege> privilegeToLocalPrivilegesMap) throws RepositoryException {
         @NotNull
@@ -492,7 +493,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
      * @param generalRestrictions the general restrictions that are not for a specific privilege
      */
     protected Set<LocalRestriction> postedRestrictionsForPrivilege(
-            @NotNull SlingHttpServletRequest request,
+            @NotNull SlingJakartaHttpServletRequest request,
             @NotNull Map<String, RestrictionDefinition> srMap,
             @NotNull Privilege forPrivilege,
             @NotNull PrivilegeValues forAllowOrDeny,
@@ -537,7 +538,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
      * @param paramName the request parameter name that contains the restriction values
      */
     protected LocalRestriction toLocalRestriction(
-            @NotNull SlingHttpServletRequest request,
+            @NotNull SlingJakartaHttpServletRequest request,
             @NotNull Map<String, RestrictionDefinition> srMap,
             @NotNull String restrictionName,
             @NotNull String paramName) throws RepositoryException {
@@ -577,7 +578,7 @@ public class ModifyAceServlet extends AbstractAccessPostServlet implements Modif
      * @param privilegeLongestDepthMap the map of privileges to their longest depth
      */
     protected void processPostedPrivilegeAndRestrictionParams(@NotNull AccessControlManager acm,
-            @NotNull SlingHttpServletRequest request,
+            @NotNull SlingJakartaHttpServletRequest request,
             @NotNull Map<String, RestrictionDefinition> srMap,
             @NotNull Map<Privilege, LocalPrivilege> privilegeToLocalPrivilegesMap,
             @NotNull Map<Privilege, Integer> privilegeLongestDepthMap) throws RepositoryException {

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyPrincipalAceServlet.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/ModifyPrincipalAceServlet.java
@@ -29,7 +29,6 @@ import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.Privilege;
-import javax.servlet.Servlet;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
@@ -40,13 +39,15 @@ import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalRestriction;
 import org.apache.sling.jcr.jackrabbit.accessmanager.ModifyPrincipalAce;
 import org.apache.sling.jcr.jackrabbit.accessmanager.impl.PrincipalAceHelper;
-import org.apache.sling.servlets.post.PostResponseCreator;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import jakarta.servlet.Servlet;
 
 /**
  * <p>
@@ -119,7 +120,7 @@ reference = {
                 bind = "bindPostResponseCreator",
                 cardinality = ReferenceCardinality.MULTIPLE,
                 policyOption = ReferencePolicyOption.GREEDY,
-                service = PostResponseCreator.class)
+                service = JakartaPostResponseCreator.class)
 })
 @SuppressWarnings("java:S110")
 public class ModifyPrincipalAceServlet extends ModifyAceServlet implements ModifyPrincipalAce {

--- a/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/package-info.java
+++ b/src/main/java/org/apache/sling/jcr/jackrabbit/accessmanager/post/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("4.0.0")
+@org.osgi.annotation.versioning.Version("5.0.0")
 package org.apache.sling.jcr.jackrabbit.accessmanager.post;
 
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessManagerClientTestSupport.java
@@ -20,8 +20,6 @@ package org.apache.sling.jcr.jackrabbit.accessmanager.it;
 
 import static org.apache.sling.testing.paxexam.SlingOptions.slingBundleresource;
 import static org.apache.sling.testing.paxexam.SlingOptions.slingCommonsCompiler;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingJcrJackrabbitAccessmanager;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingJcrJackrabbitUsermanager;
 import static org.apache.sling.testing.paxexam.SlingOptions.slingScriptingJavascript;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -39,15 +37,13 @@ import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
 
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
@@ -74,10 +70,13 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.Group;
+import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.awaitility.Awaitility;
+import org.apache.sling.jcr.api.SlingRepository;
 import org.junit.After;
 import org.junit.Before;
 import org.ops4j.pax.exam.Option;
@@ -89,6 +88,7 @@ import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * base class for tests doing http requests to verify calls to the accessmanager
@@ -129,6 +129,11 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
     protected String testGroupId = null;
     protected String testFolderUrl = null;
 
+    @Inject
+    protected SlingRepository repository;
+
+    protected Session adminSession;
+
     @Override
     protected Option[] additionalOptions() throws IOException {
         // optionally create a tinybundle that contains a test script
@@ -136,9 +141,6 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
 
         return new Option[]{
             slingBundleresource(),
-            // for usermanager support
-            slingJcrJackrabbitAccessmanager(),
-            slingJcrJackrabbitUsermanager(),
             // add javascript support for the test script
             slingCommonsCompiler(),
             when(bundle != null).useOptions(slingScriptingJavascript()),
@@ -195,24 +197,14 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
                 .disableRedirectHandling()
                 .build();
 
-        // SLING-12081 - wait for the "users" resource to be available to try to avoid flaky
-        //   failures while creating test users
-        Awaitility.await("users resource available")
-            .atMost(10000, TimeUnit.MILLISECONDS)
-            .pollInterval(1000, TimeUnit.MILLISECONDS)
-            .ignoreException(LoginException.class)
-            .until(() -> {
-                    Map<String, Object> authInfo = new HashMap<>();
-                    authInfo.put(ResourceResolverFactory.USER, "admin");
-                    authInfo.put(ResourceResolverFactory.PASSWORD, "admin".toCharArray());
-                    try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(authInfo)) {
-                        return resourceResolver.getResource("/system/userManager/user") != null;
-                    }
-                });
+        adminSession = repository.login(new SimpleCredentials("admin", "admin".toCharArray()));
+        assertNotNull("Expected adminSession to not be null", adminSession);
     }
 
     @After
     public void after() throws Exception {
+        adminSession.refresh(false);
+
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
 
         if (testFolderUrl != null) {
@@ -223,18 +215,15 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
         }
         if (testGroupId != null) {
             //remove the test user if it exists.
-            String postUrl = String.format("%s/system/userManager/group/%s.delete.html", baseServerUri, testGroupId);
-            assertAuthenticatedPostStatus(creds, postUrl, HttpServletResponse.SC_OK, Collections.emptyList(), null);
+            maybeRemoveAuthorizable(testGroupId);
         }
         if (testUserId != null) {
             //remove the test user if it exists.
-            String postUrl = String.format("%s/system/userManager/user/%s.delete.html", baseServerUri, testUserId);
-            assertAuthenticatedPostStatus(creds, postUrl, HttpServletResponse.SC_OK, Collections.emptyList(), null);
+            maybeRemoveAuthorizable(testUserId);
         }
         if (testUserId2 != null) {
             //remove the test user if it exists.
-            String postUrl = String.format("%s/system/userManager/user/%s.delete.html", baseServerUri, testUserId2);
-            assertAuthenticatedPostStatus(creds, postUrl, HttpServletResponse.SC_OK, Collections.emptyList(), null);
+            maybeRemoveAuthorizable(testUserId2);
         }
 
         // close/cleanup the test user http client
@@ -246,6 +235,11 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
         // clear out other state
         httpContext = null;
         baseServerUri = null;
+
+        if (adminSession.hasPendingChanges()) {
+            adminSession.save();
+        }
+        adminSession.logout();
     }
 
     /**
@@ -427,37 +421,36 @@ public abstract class AccessManagerClientTestSupport extends AccessManagerTestSu
         });
     }
 
-    protected String createTestUser() throws IOException {
-        String postUrl = String.format("%s/system/userManager/user.create.html", baseServerUri);
-
+    protected void maybeRemoveAuthorizable(String id) throws RepositoryException {
+        UserManager userManager = ((JackrabbitSession)adminSession).getUserManager();
+        Authorizable authorizable = userManager.getAuthorizable(id);
+        if (authorizable != null) {
+            authorizable.remove();
+            adminSession.save();
+        }
+    }
+    protected String createTestUser() throws RepositoryException {
+        UserManager userManager = ((JackrabbitSession)adminSession).getUserManager();
         String userId = "testUser" + getNextInt();
-        List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":name", userId));
-        postParams.add(new BasicNameValuePair("pwd", "testPwd"));
-        postParams.add(new BasicNameValuePair("pwdConfirm", "testPwd"));
-        Credentials creds = new UsernamePasswordCredentials("admin", "admin");
-        final String msg = "Unexpected status while attempting to create test user at " + postUrl;
-        assertAuthenticatedPostStatus(creds, postUrl, HttpServletResponse.SC_OK, postParams, msg);
-
-        final String sessionInfoUrl = String.format("%s/system/sling/info.sessionInfo.json", baseServerUri);
-        assertAuthenticatedHttpStatus(creds, sessionInfoUrl, HttpServletResponse.SC_OK,
-                "session info failed for user " + userId);
-
-        return userId;
+        User user = userManager.createUser(userId, "testPwd");
+        adminSession.save();
+        return user.getID();
     }
 
-    protected String createTestGroup() throws IOException {
-        String postUrl = String.format("%s/system/userManager/group.create.html", baseServerUri);
-
+    protected String createTestGroup() throws RepositoryException {
+        UserManager userManager = ((JackrabbitSession)adminSession).getUserManager();
         String groupId = "testGroup" + getNextInt();
-        List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":name", groupId));
+        Group group = userManager.createGroup(groupId);
+        adminSession.save();
+        return group.getID();
+    }
 
-        Credentials creds = new UsernamePasswordCredentials("admin", "admin");
-        final String msg = "Unexpected status while attempting to create test group at " + postUrl;
-        assertAuthenticatedPostStatus(creds, postUrl, HttpServletResponse.SC_OK, postParams, msg);
-
-        return groupId;
+    protected void addUserToGroup(String userId, String groupId) throws RepositoryException {
+        UserManager userManager = ((JackrabbitSession)adminSession).getUserManager();
+        Group group = userManager.getAuthorizable(groupId, Group.class);
+        User user = userManager.getAuthorizable(userId, User.class);
+        group.addMember(user);
+        adminSession.save();
     }
 
     protected String createTestFolder() throws IOException {

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessPrivilegesInfoIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/AccessPrivilegesInfoIT.java
@@ -27,10 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
@@ -43,6 +40,11 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.servlet.http.HttpServletResponse;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -59,7 +61,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
      * testuser granted read / denied write
      */
     @Test
-    public void testDeniedWriteForUser() throws IOException, JsonException {
+    public void testDeniedWriteForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -97,7 +99,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
      * testuser granted read / granted write
      */
     @Test
-    public void testGrantedWriteForUser() throws IOException, JsonException {
+    public void testGrantedWriteForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -153,7 +155,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
      * group testuser granted read / denied write
      */
     @Test
-    public void testDeniedWriteForGroup() throws IOException, JsonException {
+    public void testDeniedWriteForGroup() throws IOException, JsonException, RepositoryException {
         testGroupId = createTestGroup();
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
@@ -161,10 +163,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
         Credentials adminCreds = new UsernamePasswordCredentials("admin", "admin");
 
         //add testUserId to testGroup
-        String groupPostUrl = String.format("%s/system/userManager/group/%s.update.html", baseServerUri, testGroupId);
-        List<NameValuePair> groupPostParams = new ArrayList<>();
-        groupPostParams.add(new BasicNameValuePair(":member", testUserId));
-        assertAuthenticatedPostStatus(adminCreds, groupPostUrl, HttpServletResponse.SC_OK, groupPostParams, null);
+        addUserToGroup(testUserId, testGroupId);
 
         //assign some privileges
         String postUrl = testFolderUrl + ".modifyAce.html";
@@ -198,7 +197,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
      * group testuser granted read / granted write
      */
     @Test
-    public void testGrantedWriteForGroup() throws IOException, JsonException {
+    public void testGrantedWriteForGroup() throws IOException, JsonException, RepositoryException {
         testGroupId = createTestGroup();
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
@@ -206,10 +205,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
         Credentials adminCreds = new UsernamePasswordCredentials("admin", "admin");
 
         //add testUserId to testGroup
-        String groupPostUrl = String.format("%s/system/userManager/group/%s.update.html", baseServerUri, testGroupId);
-        List<NameValuePair> groupPostParams = new ArrayList<>();
-        groupPostParams.add(new BasicNameValuePair(":member", testUserId));
-        assertAuthenticatedPostStatus(adminCreds, groupPostUrl, HttpServletResponse.SC_OK, groupPostParams, null);
+        addUserToGroup(testUserId, testGroupId);
 
         //assign some privileges
         String postUrl = testFolderUrl + ".modifyAce.html";
@@ -263,7 +259,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
      * Test the fix for SLING-1090
      */
     @Test
-    public void testSLING1090() throws IOException {
+    public void testSLING1090() throws IOException, RepositoryException {
         testUserId = createTestUser();
 
         //grant jcr: removeChildNodes to the root node
@@ -298,7 +294,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
      * Test for SLING-7835, PrivilegesInfo#getDeclaredAccessRights returns incorrect information
      */
     @Test
-    public void testDeclaredAclForUser() throws IOException, JsonException {
+    public void testDeclaredAclForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testUserId2 = createTestUser();
 
@@ -399,7 +395,7 @@ public class AccessPrivilegesInfoIT extends AccessManagerClientTestSupport {
      * Test for SLING-7835, PrivilegesInfo#getEffectiveAccessRights returns incorrect information
      */
     @Test
-    public void testEffectiveAclForUser() throws IOException, JsonException {
+    public void testEffectiveAclForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testUserId2 = createTestUser();
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/CustomPostResponseCreatorImpl.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/CustomPostResponseCreatorImpl.java
@@ -18,21 +18,21 @@ package org.apache.sling.jcr.jackrabbit.accessmanager.it;
 
 import java.io.IOException;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.servlets.post.AbstractJakartaPostResponse;
+import org.apache.sling.servlets.post.JakartaPostResponse;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.servlets.post.AbstractPostResponse;
-import org.apache.sling.servlets.post.PostResponse;
-import org.apache.sling.servlets.post.PostResponseCreator;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Sample implementation of the PostResponseCreator interface.
  */
-public class CustomPostResponseCreatorImpl implements PostResponseCreator {
+public class CustomPostResponseCreatorImpl implements JakartaPostResponseCreator {
 
-    public PostResponse createPostResponse(SlingHttpServletRequest req) {
+    public JakartaPostResponse createPostResponse(SlingJakartaHttpServletRequest req) {
         if ("custom".equals(req.getParameter(":responseType"))) {
-            return new AbstractPostResponse() {
+            return new AbstractJakartaPostResponse() {
 
                 public void onChange(String type, String... arguments) {
                     // NO-OP

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceIT.java
@@ -24,11 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
@@ -41,6 +37,12 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.servlet.http.HttpServletResponse;
+
 /**
  * Tests for the 'ace' Sling Get Operation
  */
@@ -48,7 +50,7 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 @ExamReactorStrategy(PerClass.class)
 public class GetAceIT extends AccessManagerClientTestSupport {
 
-    protected void commonDeclaredAceForUser(String selector) throws IOException {
+    protected void commonDeclaredAceForUser(String selector) throws IOException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
@@ -82,7 +84,7 @@ public class GetAceIT extends AccessManagerClientTestSupport {
      * ACE servlet returns correct information
      */
     @Test
-    public void testDeclaredAceForUser() throws IOException, JsonException {
+    public void testDeclaredAceForUser() throws IOException, JsonException, RepositoryException {
         commonDeclaredAceForUser("ace");
     }
 
@@ -90,7 +92,7 @@ public class GetAceIT extends AccessManagerClientTestSupport {
      * ACE servlet returns correct information
      */
     @Test
-    public void testTidyDeclaredAceForUser() throws IOException, JsonException {
+    public void testTidyDeclaredAceForUser() throws IOException, JsonException, RepositoryException {
         commonDeclaredAceForUser("tidy.ace");
     }
 
@@ -98,7 +100,7 @@ public class GetAceIT extends AccessManagerClientTestSupport {
      * ACE servlet returns 404 when no declared ACE
      */
     @Test
-    public void testNoDeclaredAceForUser() throws IOException, JsonException {
+    public void testNoDeclaredAceForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
@@ -121,7 +123,7 @@ public class GetAceIT extends AccessManagerClientTestSupport {
      * ACE servlet returns 404 when no read access rights permissions
      */
     @Test
-    public void testNoAccessToDeclaredAceForUser() throws IOException, JsonException {
+    public void testNoAccessToDeclaredAceForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
@@ -144,7 +146,7 @@ public class GetAceIT extends AccessManagerClientTestSupport {
      * ACE servlet returns restriction details for leaf of also allowed aggregate
      */
     @Test
-    public void testDeclaredAceWithLeafRestrictionForUser() throws IOException, JsonException {
+    public void testDeclaredAceWithLeafRestrictionForUser() throws IOException, JsonException, RepositoryException {
         commonDeclaredAceWithLeafRestrictionForUser(1);
     }
 
@@ -153,11 +155,11 @@ public class GetAceIT extends AccessManagerClientTestSupport {
      * update to verify that the ordering doesn't get broken during update
      */
     @Test
-    public void testDeclaredAceWithLeafRestrictionForUserAfterSecondUpdate() throws IOException, JsonException {
+    public void testDeclaredAceWithLeafRestrictionForUserAfterSecondUpdate() throws IOException, JsonException, RepositoryException {
         commonDeclaredAceWithLeafRestrictionForUser(2);
     }
 
-    protected void commonDeclaredAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
+    protected void commonDeclaredAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests",
                 "{ \"jcr:primaryType\": \"nt:unstructured\" }");

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceServiceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAceServiceIT.java
@@ -27,16 +27,12 @@ import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
-import jakarta.json.JsonObject;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.sling.api.resource.ResourceNotFoundException;
-import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetAce;
 import org.apache.sling.jcr.jackrabbit.accessmanager.ModifyAce;
 import org.junit.After;
@@ -46,6 +42,8 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import jakarta.json.JsonObject;
 
 /**
  * Tests for the 'modifyAce' inproc service
@@ -60,29 +58,27 @@ public class GetAceServiceIT extends AccessManagerClientTestSupport {
     @Inject
     private GetAce getAce;
 
-    @Inject
-    protected SlingRepository repository;
-
-    protected Session adminSession;
-
     private Node testNode;
 
     @Before
-    public void setup() throws RepositoryException {
-        adminSession = repository.login(new SimpleCredentials("admin", "admin".toCharArray()));
-        assertNotNull("Expected adminSession to not be null", adminSession);
+    @Override
+    public void before() throws Exception {
+        super.before();
+
         testNode = adminSession.getRootNode().addNode("testNode");
         adminSession.save();
     }
 
     @After
-    public void teardown() throws RepositoryException {
+    @Override
+    public void after() throws Exception {
         adminSession.refresh(false);
         testNode.remove();
         if (adminSession.hasPendingChanges()) {
             adminSession.save();
         }
-        adminSession.logout();
+
+        super.after();
     }
 
     protected JsonObject ace(String path, String principalId) throws RepositoryException {

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAclIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetAclIT.java
@@ -23,9 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.List;
 
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
@@ -36,6 +34,10 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Tests for the 'acl' and 'eacl' Sling Get Operation
@@ -48,7 +50,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * Test for SLING-2600, Effective ACL servlet returns incorrect information
      */
     @Test
-    public void testEffectiveAclForUser() throws IOException, JsonException {
+    public void testEffectiveAclForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testUserId2 = createTestUser();
 
@@ -110,7 +112,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * Test for SLING-2600, Effective ACL servlet returns incorrect information
      */
     @Test
-    public void testEffectiveAclMergeForUserReplacePrivilegeOnChild() throws IOException, JsonException {
+    public void testEffectiveAclMergeForUserReplacePrivilegeOnChild() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder(null, "sling-tests",
@@ -153,7 +155,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * Test for SLING-2600, Effective ACL servlet returns incorrect information
      */
     @Test
-    public void testEffectiveAclMergeForUserFewerPrivilegesGrantedOnChild() throws IOException, JsonException {
+    public void testEffectiveAclMergeForUserFewerPrivilegesGrantedOnChild() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder(null, "sling-tests",
@@ -195,7 +197,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * Test for SLING-2600, Effective ACL servlet returns incorrect information
      */
     @Test
-    public void testEffectiveAclMergeForUserMorePrivilegesGrantedOnChild() throws IOException, JsonException {
+    public void testEffectiveAclMergeForUserMorePrivilegesGrantedOnChild() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder(null, "sling-tests",
@@ -237,7 +239,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * Test for SLING-2600, Effective ACL servlet returns incorrect information
      */
     @Test
-    public void testEffectiveAclMergeForUserSubsetOfPrivilegesDeniedOnChild2() throws IOException, JsonException {
+    public void testEffectiveAclMergeForUserSubsetOfPrivilegesDeniedOnChild2() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder(null, "sling-tests",
@@ -294,7 +296,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * Test for SLING-2600, Effective ACL servlet returns incorrect information
      */
     @Test
-    public void testEffectiveAclMergeForUserSupersetOfPrivilegesDeniedOnChild() throws IOException, JsonException {
+    public void testEffectiveAclMergeForUserSupersetOfPrivilegesDeniedOnChild() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder(null, "sling-tests",
@@ -335,7 +337,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * Test for SLING-2600, Effective ACL servlet returns incorrect information
      */
     @Test
-    public void testEffectiveAclMergeForUserSupersetOfPrivilegesDeniedOnChild2() throws IOException, JsonException {
+    public void testEffectiveAclMergeForUserSupersetOfPrivilegesDeniedOnChild2() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder(null, "sling-tests",
@@ -376,7 +378,7 @@ public class GetAclIT extends AccessManagerClientTestSupport {
      * ACL servlet returns 404 when no read access rights permissions
      */
     @Test
-    public void testNoAccessToDeclaredAclForUser() throws IOException, JsonException {
+    public void testNoAccessToDeclaredAclForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceIT.java
@@ -26,12 +26,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.stream.Stream;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
@@ -44,6 +39,13 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.servlet.http.HttpServletResponse;
+
 /**
  * Tests for the 'eace' Sling Get Operation
  */
@@ -51,7 +53,7 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 @ExamReactorStrategy(PerClass.class)
 public class GetEaceIT extends AccessManagerClientTestSupport {
 
-    protected void commonEffectiveAceForUser(String selector) throws IOException {
+    protected void commonEffectiveAceForUser(String selector) throws IOException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests1",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
@@ -90,7 +92,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * Effective ACE servlet returns correct information
      */
     @Test
-    public void testEffectiveAceForUser() throws IOException, JsonException {
+    public void testEffectiveAceForUser() throws IOException, JsonException, RepositoryException {
         commonEffectiveAceForUser("eace");
     }
 
@@ -98,7 +100,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * Effective ACE servlet returns correct information
      */
     @Test
-    public void testTidyEffectiveAceForUser() throws IOException, JsonException {
+    public void testTidyEffectiveAceForUser() throws IOException, JsonException, RepositoryException {
         commonEffectiveAceForUser("tidy.eace");
     }
 
@@ -106,7 +108,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * Effective ACE servlet returns correct information
      */
     @Test
-    public void testNoEffectiveAceForUser() throws IOException, JsonException {
+    public void testNoEffectiveAceForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testUserId2 = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests2",
@@ -129,7 +131,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * Effective ACE servlet returns 404 when no read access rights permissions
      */
     @Test
-    public void testNoAccessToEffectiveAceForUser() throws IOException, JsonException {
+    public void testNoAccessToEffectiveAceForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests2",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
@@ -152,7 +154,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * ACE servlet returns restriction details for leaf of also allowed aggregate
      */
     @Test
-    public void testEffectiveAceWithLeafRestrictionForUser() throws IOException, JsonException {
+    public void testEffectiveAceWithLeafRestrictionForUser() throws IOException, JsonException, RepositoryException {
         commonEffectiveAceWithLeafRestrictionForUser(1);
     }
 
@@ -161,11 +163,11 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * update to verify that the ordering doesn't get broken during update
      */
     @Test
-    public void testEffectiveAceWithLeafRestrictionForUserAfterSecondUpdate() throws IOException, JsonException {
+    public void testEffectiveAceWithLeafRestrictionForUserAfterSecondUpdate() throws IOException, JsonException, RepositoryException {
         commonEffectiveAceWithLeafRestrictionForUser(2);
     }
 
-    protected void commonEffectiveAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException {
+    protected void commonEffectiveAceWithLeafRestrictionForUser(int numberOfUpdateAceCalls) throws IOException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests2",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
@@ -231,7 +233,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * declaredAt structure
      */
     @Test
-    public void testDeclaredAtArrayInEffectiveAceForUser() throws IOException {
+    public void testDeclaredAtArrayInEffectiveAceForUser() throws IOException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests1",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");
@@ -283,7 +285,7 @@ public class GetEaceIT extends AccessManagerClientTestSupport {
      * Effective ACE servlet returns correct information
      */
     @Test
-    public void testEffectiveAceForUserWithMergedRestrictionValues() throws IOException, JsonException {
+    public void testEffectiveAceForUserWithMergedRestrictionValues() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests2",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true, \"childPropTwo\" : \"two\" } }");

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceServiceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetEaceServiceIT.java
@@ -27,16 +27,12 @@ import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
-import jakarta.json.JsonObject;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.sling.api.resource.ResourceNotFoundException;
-import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetEffectiveAce;
 import org.apache.sling.jcr.jackrabbit.accessmanager.ModifyAce;
 import org.junit.After;
@@ -46,6 +42,8 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import jakarta.json.JsonObject;
 
 /**
  * Tests for the 'modifyAce' inproc service
@@ -60,29 +58,26 @@ public class GetEaceServiceIT extends AccessManagerClientTestSupport {
     @Inject
     private GetEffectiveAce getEffectiveAce;
 
-    @Inject
-    protected SlingRepository repository;
-
-    protected Session adminSession;
-
     private Node testNode;
 
     @Before
-    public void setup() throws RepositoryException {
-        adminSession = repository.login(new SimpleCredentials("admin", "admin".toCharArray()));
-        assertNotNull("Expected adminSession to not be null", adminSession);
+    @Override
+    public void before() throws Exception {
+        super.before();
         testNode = adminSession.getRootNode().addNode("testNode");
         adminSession.save();
     }
 
     @After
-    public void teardown() throws RepositoryException {
+    @Override
+    public void after() throws Exception {
         adminSession.refresh(false);
         testNode.remove();
         if (adminSession.hasPendingChanges()) {
             adminSession.save();
         }
-        adminSession.logout();
+
+        super.after();
     }
 
     protected JsonObject ace(String path, String principalId) throws RepositoryException {

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/GetPaceIT.java
@@ -25,12 +25,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.stream.Stream;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
@@ -42,6 +37,13 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Tests for the 'pace' Sling Get Operation
@@ -90,7 +92,7 @@ public class GetPaceIT extends PrincipalAceTestSupport {
      * Privilege ACE servlet returns 404 when no read access rights permissions
      */
     @Test
-    public void testNoAccessToPrivilegeAceForUser() throws IOException, JsonException {
+    public void testNoAccessToPrivilegeAceForUser() throws IOException, JsonException, RepositoryException {
         String testServiceUserId = "pacetestuser";
         testFolderUrl = createTestFolder(null, "sling-tests1",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceIT.java
@@ -31,21 +31,15 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
-import jakarta.json.JsonValue.ValueType;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
 
 import org.apache.http.NameValuePair;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.apache.sling.servlets.post.JSONResponse;
-import org.apache.sling.servlets.post.PostResponseCreator;
+import org.apache.sling.servlets.post.JakartaJSONResponse;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +51,14 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonValue.ValueType;
+import jakarta.servlet.http.HttpServletResponse;
+
 /**
  * Tests for the 'modifyAce' Sling Post Operation
  */
@@ -64,7 +66,7 @@ import org.osgi.framework.ServiceRegistration;
 @ExamReactorStrategy(PerClass.class)
 public class ModifyAceIT extends AccessManagerClientTestSupport {
 
-    private ServiceRegistration<PostResponseCreator> serviceReg;
+    private ServiceRegistration<JakartaPostResponseCreator> serviceReg;
     private ServiceRegistration<RestrictionProvider> serviceReg2;
     private VerifyAce verifyTrue = jsonValue -> assertEquals(ValueType.TRUE, jsonValue.getValueType());
 
@@ -73,7 +75,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     public void before() throws Exception {
         Bundle bundle = FrameworkUtil.getBundle(getClass());
         Dictionary<String, Object> props = new Hashtable<>(); // NOSONAR
-        serviceReg = bundle.getBundleContext().registerService(PostResponseCreator.class,
+        serviceReg = bundle.getBundleContext().registerService(JakartaPostResponseCreator.class,
                 new CustomPostResponseCreatorImpl(), props);
         serviceReg2 = bundle.getBundleContext().registerService(RestrictionProvider.class,
                 new CustomRestrictionProviderImpl(), props);
@@ -95,7 +97,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testModifyAceForUser() throws IOException, JsonException {
+    public void testModifyAceForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
@@ -127,7 +129,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * Test for SLING-7831
      */
     @Test
-    public void testModifyAceCustomPostResponse() throws IOException, JsonException {
+    public void testModifyAceCustomPostResponse() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
@@ -144,7 +146,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testModifyAceForGroup() throws IOException, JsonException {
+    public void testModifyAceForGroup() throws IOException, JsonException, RepositoryException {
         testGroupId = createTestGroup();
 
         testFolderUrl = createTestFolder();
@@ -180,7 +182,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * request.
      */
     @Test
-    public void testMergeAceForUser() throws IOException, JsonException {
+    public void testMergeAceForUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -251,7 +253,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * request.
      */
     @Test
-    public void testMergeAceForUserSplitAggregatePrincipal() throws IOException, JsonException {
+    public void testMergeAceForUserSplitAggregatePrincipal() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -297,7 +299,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * request.
      */
     @Test
-    public void testMergeAceForUserCombineAggregatePrivilege() throws IOException, JsonException {
+    public void testMergeAceForUserCombineAggregatePrivilege() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -353,7 +355,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * a grant privilege
      */
     @Test
-    public void testMergeAceForUserDenyPrivilegeAfterGrantPrivilege() throws IOException, JsonException {
+    public void testMergeAceForUserDenyPrivilegeAfterGrantPrivilege() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -399,7 +401,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
         assertPrivilege(privilegesObject2, true, PrivilegeValues.DENY, PrivilegeConstants.JCR_NODE_TYPE_MANAGEMENT);
     }
 
-    protected void commonAddAceOrderBy(String order) throws IOException {
+    protected void commonAddAceOrderBy(String order) throws IOException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -425,7 +427,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceOrderByEmpty() throws IOException, JsonException {
+    public void testAddAceOrderByEmpty() throws IOException, JsonException, RepositoryException {
         commonAddAceOrderBy("");
     }
 
@@ -434,7 +436,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceOrderByNull() throws IOException, JsonException {
+    public void testAddAceOrderByNull() throws IOException, JsonException, RepositoryException {
         commonAddAceOrderBy(null);
     }
 
@@ -443,7 +445,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceOrderByFirst() throws IOException, JsonException {
+    public void testAddAceOrderByFirst() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -469,7 +471,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceOrderByLast() throws IOException, JsonException {
+    public void testAddAceOrderByLast() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -496,7 +498,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceOrderByBefore() throws IOException, JsonException {
+    public void testAddAceOrderByBefore() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -522,7 +524,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceOrderByAfter() throws IOException, JsonException {
+    public void testAddAceOrderByAfter() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -548,7 +550,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceOrderByNumeric() throws IOException, JsonException {
+    public void testAddAceOrderByNumeric() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -598,7 +600,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * leaves the ACE in the same position in the ACL
      */
     @Test
-    public void testUpdateAcePreservePosition() throws IOException, JsonException {
+    public void testUpdateAcePreservePosition() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -626,7 +628,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     /**
      * Helper to create a test folder with a single ACE pre-created
      */
-    private void createAceOrderTestFolderWithOneAce() throws IOException, JsonException {
+    private void createAceOrderTestFolderWithOneAce() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
@@ -688,7 +690,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * Test for SLING-1677
      */
     @Test
-    public void testModifyAceResponseAsJSON() throws IOException, JsonException {
+    public void testModifyAceResponseAsJSON() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
@@ -711,7 +713,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * Test for SLING-3010
      */
     @Test
-    public void testMergeAceForUserGrantNestedAggregatePrivilegeAfterDenySuperAggregatePrivilege() throws IOException, JsonException {
+    public void testMergeAceForUserGrantNestedAggregatePrivilegeAfterDenySuperAggregatePrivilege() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
@@ -756,7 +758,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * Test for SLING-3010
      */
     @Test
-    public void testMergeAceForUserGrantAggregatePrivilegePartsAfterDenyAggregatePrivilege() throws IOException, JsonException {
+    public void testMergeAceForUserGrantAggregatePrivilegePartsAfterDenyAggregatePrivilege() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
@@ -801,7 +803,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceWithRestriction() throws IOException, JsonException {
+    public void testAddAceWithRestriction() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -871,7 +873,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testUpdateAceToMergeNewRestriction() throws IOException, JsonException {
+    public void testUpdateAceToMergeNewRestriction() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -958,7 +960,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-8117 - Test to verify removing a restriction from an ACE
      */
     @Test
-    public void testUpdateAceToRemoveRestriction() throws IOException, JsonException {
+    public void testUpdateAceToRemoveRestriction() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -1040,7 +1042,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * if a new value with the same name has also been supplied
      */
     @Test
-    public void testUpdateAceToRemoveRestrictionWithConflict() throws IOException, JsonException {
+    public void testUpdateAceToRemoveRestrictionWithConflict() throws IOException, JsonException, RepositoryException {
         createAceOrderTestFolderWithOneAce();
 
         testGroupId = createTestGroup();
@@ -1128,7 +1130,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
 
         // update the ACE
         List<NameValuePair> postParams = new AcePostParamsBuilder(invalidUserId)
-                .with(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE)
+                .with(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE)
                 .withPrivilege(PrivilegeConstants.JCR_READ, PrivilegeValues.ALLOW)
                 .withPrivilege(PrivilegeConstants.JCR_WRITE, PrivilegeValues.DENY)
                 .withPrivilege(PrivilegeConstants.JCR_MODIFY_ACCESS_CONTROL, PrivilegeValues.BOGUS)//invalid value should be ignored.
@@ -1145,14 +1147,14 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * returns the list of principals that were changed
      */
     @Test
-    public void testModifyAceChangesInResponse() throws IOException, JsonException {
+    public void testModifyAceChangesInResponse() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
 
         // update the ACE
         List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
-                .with(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE)
+                .with(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE)
                 .withPrivilege(PrivilegeConstants.JCR_READ, PrivilegeValues.ALLOW)
                 .withPrivilege(PrivilegeConstants.JCR_WRITE, PrivilegeValues.DENY)
                 .withPrivilege(PrivilegeConstants.JCR_MODIFY_ACCESS_CONTROL, PrivilegeValues.BOGUS)//invalid value should be ignored.
@@ -1169,7 +1171,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
         assertEquals(testUserId, change.getString("argument"));
     }
 
-    private void testModifyAceRedirect(String redirectTo, int expectedStatus) throws IOException {
+    private void testModifyAceRedirect(String redirectTo, int expectedStatus) throws IOException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
@@ -1183,17 +1185,17 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testModifyAceValidRedirect() throws IOException, JsonException {
+    public void testModifyAceValidRedirect() throws IOException, JsonException, RepositoryException {
         testModifyAceRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
     }
 
     @Test
-    public void testModifyAceInvalidRedirectWithAuthority() throws IOException, JsonException {
+    public void testModifyAceInvalidRedirectWithAuthority() throws IOException, JsonException, RepositoryException {
         testModifyAceRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
     }
 
     @Test
-    public void testModifyAceInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+    public void testModifyAceInvalidRedirectWithInvalidURI() throws IOException, JsonException, RepositoryException {
         testModifyAceRedirect("https://", SC_UNPROCESSABLE_ENTITY);
     }
 
@@ -1202,7 +1204,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceAddAllowPrivilegeRestriction() throws IOException, JsonException {
+    public void testModifyAceAddAllowPrivilegeRestriction() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1251,7 +1253,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceAddDenyPrivilegeRestriction() throws IOException, JsonException {
+    public void testModifyAceAddDenyPrivilegeRestriction() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1300,7 +1302,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceAddAllowAndDenyPrivilegeRestriction() throws IOException, JsonException {
+    public void testModifyAceAddAllowAndDenyPrivilegeRestriction() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1349,7 +1351,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify modifying an ACE to remove a privilege
      */
     @Test
-    public void testModifyAceDeleteWriteAllowPrivilege() throws IOException, JsonException {
+    public void testModifyAceDeleteWriteAllowPrivilege() throws IOException, JsonException, RepositoryException {
         commonModifyAceDeleteWritePrivilege();
 
         // remove just the allow privilege and leave the deny privilege active
@@ -1379,7 +1381,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify modifying an ACE to remove a privilege
      */
     @Test
-    public void testModifyAceDeleteWritePrivilegeWithInvalidValue() throws IOException, JsonException {
+    public void testModifyAceDeleteWritePrivilegeWithInvalidValue() throws IOException, JsonException, RepositoryException {
         commonModifyAceDeleteWritePrivilege();
 
         // remove with an invalid value
@@ -1418,7 +1420,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify modifying an ACE to remove a privilege
      */
     @Test
-    public void testModifyAceDeleteWriteDenyPrivilege() throws IOException, JsonException {
+    public void testModifyAceDeleteWriteDenyPrivilege() throws IOException, JsonException, RepositoryException {
         commonModifyAceDeleteWritePrivilege();
 
         // remove just the deny privilege and leave the allow privilege active
@@ -1448,7 +1450,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify modifying an ACE to remove a privilege
      */
     @Test
-    public void testModifyAceDeleteWriteAllPrivilege() throws IOException, JsonException {
+    public void testModifyAceDeleteWriteAllPrivilege() throws IOException, JsonException, RepositoryException {
         commonModifyAceDeleteWritePrivilege();
 
         // remove both the allow and the deny privilege
@@ -1465,7 +1467,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
         assertPrivilege(groupPrivilegesObject2, false, PrivilegeValues.DENY, PrivilegeConstants.JCR_WRITE);
     }
 
-    protected void commonModifyAceDeleteWritePrivilege() throws IOException {
+    protected void commonModifyAceDeleteWritePrivilege() throws IOException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1508,7 +1510,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * The allow restriction wins out and the deny restriction is ignored
      */
     @Test
-    public void testModifyAceAllowWinsOverDenyWithSameRestrictions() throws IOException, JsonException {
+    public void testModifyAceAllowWinsOverDenyWithSameRestrictions() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1540,7 +1542,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDeleteAllowPrivilegeRestriction() throws IOException, JsonException {
+    public void testModifyAceDeleteAllowPrivilegeRestriction() throws IOException, JsonException, RepositoryException {
         testModifyAceAddAllowAndDenyPrivilegeRestriction();
 
         // update the ACE
@@ -1576,7 +1578,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDeletePrivilegeRestrictionWithInvalidValue() throws IOException, JsonException {
+    public void testModifyAceDeletePrivilegeRestrictionWithInvalidValue() throws IOException, JsonException, RepositoryException {
         testModifyAceAddAllowAndDenyPrivilegeRestriction();
 
         // update the ACE
@@ -1624,7 +1626,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDeleteDenyPrivilegeRestriction() throws IOException, JsonException {
+    public void testModifyAceDeleteDenyPrivilegeRestriction() throws IOException, JsonException, RepositoryException {
         testModifyAceAddAllowAndDenyPrivilegeRestriction();
 
         // update the ACE
@@ -1660,7 +1662,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDeleteAllowAndDenyPrivilegeRestriction() throws IOException, JsonException {
+    public void testModifyAceDeleteAllowAndDenyPrivilegeRestriction() throws IOException, JsonException, RepositoryException {
         testModifyAceAddAllowAndDenyPrivilegeRestriction();
 
         // update the ACE
@@ -1684,7 +1686,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceAddPrivilegeRestrictionOnAggregateLeaf() throws IOException, JsonException {
+    public void testModifyAceAddPrivilegeRestrictionOnAggregateLeaf() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1727,7 +1729,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceAddSamePrivilegeRestrictionOnAllAggregateLeafs() throws IOException, JsonException {
+    public void testModifyAceAddSamePrivilegeRestrictionOnAllAggregateLeafs() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1760,7 +1762,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceAllowAllDenyReadAccessControl() throws IOException, JsonException {
+    public void testModifyAceAllowAllDenyReadAccessControl() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1800,7 +1802,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDenyAllAllowReadAccessControl() throws IOException, JsonException {
+    public void testModifyAceDenyAllAllowReadAccessControl() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1840,7 +1842,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDenyAllAllowReadProperties() throws IOException, JsonException {
+    public void testModifyAceDenyAllAllowReadProperties() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1882,7 +1884,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDenyAllGrantLeafsOfRepWrite() throws IOException, JsonException {
+    public void testModifyAceDenyAllGrantLeafsOfRepWrite() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1925,7 +1927,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDenyAllGrantModifyPropertiesAndOtherLeafsOfRepWrite() throws IOException, JsonException {
+    public void testModifyAceDenyAllGrantModifyPropertiesAndOtherLeafsOfRepWrite() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -1967,7 +1969,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceDenyAllGrantJcrWriteAndOtherLeafsOfRepWrite() throws IOException, JsonException {
+    public void testModifyAceDenyAllGrantJcrWriteAndOtherLeafsOfRepWrite() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2007,7 +2009,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * SLING-11243 - Test to verify adding an ACE with privilege restriction
      */
     @Test
-    public void testModifyAceAllowAllDenyJcrWriteAndOtherLeafsOfRepWrite() throws IOException, JsonException {
+    public void testModifyAceAllowAllDenyJcrWriteAndOtherLeafsOfRepWrite() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2048,7 +2050,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * The allow restriction wins out and the deny restriction is ignored
      */
     @Test
-    public void testModifyAceAllowReadAndDenyRead() throws IOException, JsonException {
+    public void testModifyAceAllowReadAndDenyRead() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2077,7 +2079,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * The allow restriction wins out and the deny restriction is ignored
      */
     @Test
-    public void testModifyAceDenyReadAndAllowRead() throws IOException, JsonException {
+    public void testModifyAceDenyReadAndAllowRead() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2106,7 +2108,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * The allow restriction wins out and the deny restriction is ignored
      */
     @Test
-    public void testModifyAceAllowReadAndNoneRead() throws IOException, JsonException {
+    public void testModifyAceAllowReadAndNoneRead() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2136,7 +2138,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * The allow restriction wins out and the deny restriction is ignored
      */
     @Test
-    public void testModifyAceAllowReadRestrictionAndDenySameReadRestriction() throws IOException, JsonException {
+    public void testModifyAceAllowReadRestrictionAndDenySameReadRestriction() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2175,7 +2177,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * The allow restriction wins out and the deny restriction is ignored
      */
     @Test
-    public void testModifyAceDenyReadRestrictionAndAllowSameReadRestriction() throws IOException, JsonException {
+    public void testModifyAceDenyReadRestrictionAndAllowSameReadRestriction() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2214,7 +2216,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * The allow restriction wins out and the deny restriction is ignored
      */
     @Test
-    public void testModifyAceAllowReadRestrictionAndNoneSameReadRestriction() throws IOException, JsonException {
+    public void testModifyAceAllowReadRestrictionAndNoneSameReadRestriction() throws IOException, JsonException, RepositoryException {
         testFolderUrl = createTestFolder();
         testGroupId = createTestGroup();
 
@@ -2249,14 +2251,14 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testModifyAceForInvalidRestrictionName() throws IOException, JsonException {
+    public void testModifyAceForInvalidRestrictionName() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
 
         // update the ACE
         List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
-                .with(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE)
+                .with(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE)
                 .withRestriction("invalid_name", "hello")
                 .build();
         String json = addOrUpdateAce(testFolderUrl, postParams, CONTENT_TYPE_JSON, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -2267,14 +2269,14 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testModifyAceForInvalidPrivilegeName() throws IOException, JsonException {
+    public void testModifyAceForInvalidPrivilegeName() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
 
         // update the ACE
         List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
-                .with(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE)
+                .with(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE)
                 .withPrivilege("invalid_name", PrivilegeValues.ALLOW)
                 .build();
         String json = addOrUpdateAce(testFolderUrl, postParams, CONTENT_TYPE_JSON, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -2285,14 +2287,14 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testModifyAceForInvalidDeleteRestrictionName() throws IOException, JsonException {
+    public void testModifyAceForInvalidDeleteRestrictionName() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
 
         // update the ACE
         List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
-                .with(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE)
+                .with(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE)
                 .withDeletePrivilegeRestriction(PrivilegeConstants.JCR_READ, "invalid_name", DeleteValues.ALLOW)
                 .build();
         String json = addOrUpdateAce(testFolderUrl, postParams, CONTENT_TYPE_JSON, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -2303,14 +2305,14 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testModifyAceForInvalidDeleteRestrictionPrivilegeName() throws IOException, JsonException {
+    public void testModifyAceForInvalidDeleteRestrictionPrivilegeName() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
 
         testFolderUrl = createTestFolder();
 
         // update the ACE
         List<NameValuePair> postParams = new AcePostParamsBuilder(testUserId)
-                .with(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE)
+                .with(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE)
                 .withDeletePrivilegeRestriction("invalid_name", AccessControlConstants.REP_GLOB, DeleteValues.ALLOW)
                 .build();
         String json = addOrUpdateAce(testFolderUrl, postParams, CONTENT_TYPE_JSON, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -2325,7 +2327,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * the ACL
      */
     @Test
-    public void testAddAceWithCustomRestriction() throws IOException, JsonException {
+    public void testAddAceWithCustomRestriction() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -2371,7 +2373,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * when there is a deny child privilege with the same restrictions as the parent
      */
     @Test
-    public void testNoAggregateAllowWhenDenyChildHasSameRestriction() throws IOException, JsonException {
+    public void testNoAggregateAllowWhenDenyChildHasSameRestriction() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -2419,7 +2421,7 @@ public class ModifyAceIT extends AccessManagerClientTestSupport {
      * when there is an allow child privilege with the same restrictions as the parent
      */
     @Test
-    public void testNoAggregateDenyWhenAllowChildHasSameRestriction() throws IOException, JsonException {
+    public void testNoAggregateDenyWhenAllowChildHasSameRestriction() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceServiceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyAceServiceIT.java
@@ -31,19 +31,13 @@ import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
 import javax.jcr.security.AccessControlException;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.sling.api.resource.ResourceNotFoundException;
-import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetAcl;
 import org.apache.sling.jcr.jackrabbit.accessmanager.LocalPrivilege;
 import org.apache.sling.jcr.jackrabbit.accessmanager.ModifyAce;
@@ -54,6 +48,10 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 
 /**
  * Tests for the 'modifyAce' inproc service
@@ -68,29 +66,29 @@ public class ModifyAceServiceIT extends AccessManagerClientTestSupport {
     @Inject
     private GetAcl getAcl;
 
-    @Inject
-    protected SlingRepository repository;
-
-    protected Session adminSession;
-
     private Node testNode;
 
+
     @Before
-    public void setup() throws RepositoryException {
-        adminSession = repository.login(new SimpleCredentials("admin", "admin".toCharArray()));
-        assertNotNull("Expected adminSession to not be null", adminSession);
+    @Override
+    public void before() throws Exception {
+        super.before();
+
         testNode = adminSession.getRootNode().addNode("testNode");
         adminSession.save();
     }
 
+
     @After
-    public void teardown() throws RepositoryException {
+    @Override
+    public void after() throws Exception {
         adminSession.refresh(false);
         testNode.remove();
         if (adminSession.hasPendingChanges()) {
             adminSession.save();
         }
-        adminSession.logout();
+
+        super.after();
     }
 
     protected JsonObject acl(String path) throws RepositoryException {

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyPrincipalAceIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/ModifyPrincipalAceIT.java
@@ -22,9 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import java.util.List;
 
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import javax.servlet.http.HttpServletResponse;
+import javax.jcr.RepositoryException;
 
 import org.apache.http.NameValuePair;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
@@ -33,6 +31,10 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Tests for the 'pace' Sling Get Operation
@@ -75,7 +77,7 @@ public class ModifyPrincipalAceIT extends PrincipalAceTestSupport {
      * Privilege ACE servlet returns error for non-service user
      */
     @Test
-    public void testModifyPrivilegeAceForNonServiceUser() throws IOException, JsonException {
+    public void testModifyPrivilegeAceForNonServiceUser() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder(null, "sling-tests",
                 "{ \"jcr:primaryType\": \"nt:unstructured\", \"child\" : { \"childPropOne\" : true } }");

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/PrincipalAceServiceTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/PrincipalAceServiceTestSupport.java
@@ -21,14 +21,12 @@ import static org.junit.Assert.assertNotNull;
 import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
-import jakarta.json.JsonObject;
 
-import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetPrincipalAce;
 import org.junit.After;
 import org.junit.Before;
+
+import jakarta.json.JsonObject;
 
 /**
  * Base class for testing of the principal ACE operations
@@ -38,19 +36,12 @@ public abstract class PrincipalAceServiceTestSupport extends PrincipalAceTestSup
     @Inject
     protected GetPrincipalAce getPrincipalAce;
 
-    @Inject
-    protected SlingRepository repository;
-
-    protected Session adminSession;
-
     protected Node testNode;
 
     @Override
     @Before
     public void before() throws Exception {
         super.before();
-        adminSession = repository.login(new SimpleCredentials("admin", "admin".toCharArray()));
-        assertNotNull("Expected adminSession to not be null", adminSession);
         testNode = adminSession.getRootNode().addNode("testNode");
         adminSession.save();
     }
@@ -64,7 +55,6 @@ public abstract class PrincipalAceServiceTestSupport extends PrincipalAceTestSup
             if (adminSession.hasPendingChanges()) {
                 adminSession.save();
             }
-            adminSession.logout();
         }
         super.after();
     }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/PrincipalAceTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/PrincipalAceTestSupport.java
@@ -26,15 +26,15 @@ import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
 import java.io.IOException;
 import java.util.List;
 
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.ops4j.pax.exam.Option;
+
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Base class for testing of the principal ACE operations

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemoveAcesIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemoveAcesIT.java
@@ -25,18 +25,20 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 
+import javax.jcr.RepositoryException;
+
 import jakarta.json.JsonArray;
 import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.apache.sling.servlets.post.JSONResponse;
-import org.apache.sling.servlets.post.PostResponseCreator;
+import org.apache.sling.servlets.post.JakartaJSONResponse;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,14 +57,14 @@ import org.osgi.framework.ServiceRegistration;
 @ExamReactorStrategy(PerClass.class)
 public class RemoveAcesIT extends AccessManagerClientTestSupport {
 
-    private ServiceRegistration<PostResponseCreator> serviceReg;
+    private ServiceRegistration<JakartaPostResponseCreator> serviceReg;
 
     @Before
     @Override
     public void before() throws Exception {
         Bundle bundle = FrameworkUtil.getBundle(getClass());
         Dictionary<String, Object> props = new Hashtable<>(); // NOSONAR
-        serviceReg = bundle.getBundleContext().registerService(PostResponseCreator.class,
+        serviceReg = bundle.getBundleContext().registerService(JakartaPostResponseCreator.class,
                 new CustomPostResponseCreatorImpl(), props);
 
         super.before();
@@ -79,7 +81,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
     }
 
 
-    private String createFolderWithAces(boolean addGroupAce) throws IOException, JsonException {
+    private String createFolderWithAces(boolean addGroupAce) throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
@@ -145,7 +147,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
 
     //test removing a single ace
     @Test
-    public void testRemoveAce() throws IOException, JsonException {
+    public void testRemoveAce() throws IOException, JsonException, RepositoryException {
         String folderUrl = createFolderWithAces(false);
 
         //remove the ace for the testUser principal
@@ -170,7 +172,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
      * Test for SLING-7831
      */
     @Test
-    public void testRemoveAceCustomPostResponse() throws IOException, JsonException {
+    public void testRemoveAceCustomPostResponse() throws IOException, JsonException, RepositoryException {
         String folderUrl = createFolderWithAces(false);
 
         //remove the ace for the testUser principal
@@ -186,7 +188,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
 
     //test removing multiple aces
     @Test
-    public void testRemoveAces() throws IOException, JsonException {
+    public void testRemoveAces() throws IOException, JsonException, RepositoryException {
         String folderUrl = createFolderWithAces(true);
 
         //remove the ace for the testUser principal
@@ -212,7 +214,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
      * Test for SLING-1677
      */
     @Test
-    public void testRemoveAcesResponseAsJSON() throws IOException, JsonException {
+    public void testRemoveAcesResponseAsJSON() throws IOException, JsonException, RepositoryException {
         String folderUrl = createFolderWithAces(true);
 
         //remove the ace for the testUser principal
@@ -234,14 +236,14 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
      * in a consistent way to other scenarios
      */
     @Test
-    public void testRemoveAceWhenAccessControlListDoesNotExist() throws IOException, JsonException {
+    public void testRemoveAceWhenAccessControlListDoesNotExist() throws IOException, JsonException, RepositoryException {
         testUserId = createTestUser();
         testFolderUrl = createTestFolder();
 
         String postUrl = testFolderUrl + ".deleteAce.json";
 
         List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE));
+        postParams.add(new BasicNameValuePair(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE));
         postParams.add(new BasicNameValuePair(":applyTo", testUserId));
 
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
@@ -259,7 +261,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
      * good error message instead of a NullPointerException
      */
     @Test
-    public void testRemoveAceForInvalidUser() throws IOException, JsonException {
+    public void testRemoveAceForInvalidUser() throws IOException, JsonException, RepositoryException {
         String invalidUserId = "notRealUser123";
 
         String folderUrl = createFolderWithAces(true);
@@ -267,7 +269,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
         String postUrl = folderUrl + ".deleteAce.json";
 
         List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE));
+        postParams.add(new BasicNameValuePair(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE));
         postParams.add(new BasicNameValuePair(":applyTo", invalidUserId));
 
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
@@ -283,13 +285,13 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
      * returns the list of principals that were changed
      */
     @Test
-    public void testRemoveAceChangesInResponse() throws IOException, JsonException {
+    public void testRemoveAceChangesInResponse() throws IOException, JsonException, RepositoryException {
         String folderUrl = createFolderWithAces(true);
 
         String postUrl = folderUrl + ".deleteAce.json";
 
         List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE));
+        postParams.add(new BasicNameValuePair(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE));
         postParams.add(new BasicNameValuePair(":applyTo", testUserId));
 
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
@@ -305,7 +307,7 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
         assertEquals(testUserId, change.getString("argument"));
     }
 
-    private void testRemoveAceRedirect(String redirectTo, int expectedStatus) throws IOException {
+    private void testRemoveAceRedirect(String redirectTo, int expectedStatus) throws IOException, JsonException, RepositoryException {
         String folderUrl = createFolderWithAces(false);
 
         //remove the ace for the testUser principal
@@ -318,17 +320,17 @@ public class RemoveAcesIT extends AccessManagerClientTestSupport {
     }
 
     @Test
-    public void testRemoveAceValidRedirect() throws IOException, JsonException {
+    public void testRemoveAceValidRedirect() throws IOException, JsonException, RepositoryException {
         testRemoveAceRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
     }
 
     @Test
-    public void testRemoveAceInvalidRedirectWithAuthority() throws IOException, JsonException {
+    public void testRemoveAceInvalidRedirectWithAuthority() throws IOException, JsonException, RepositoryException {
         testRemoveAceRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
     }
 
     @Test
-    public void testRemoveAceInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+    public void testRemoveAceInvalidRedirectWithInvalidURI() throws IOException, JsonException, RepositoryException {
         testRemoveAceRedirect("https://", SC_UNPROCESSABLE_ENTITY);
     }
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemovePrincipalAcesIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/accessmanager/it/RemovePrincipalAcesIT.java
@@ -26,18 +26,13 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.apache.sling.servlets.post.JSONResponse;
-import org.apache.sling.servlets.post.PostResponseCreator;
+import org.apache.sling.servlets.post.JakartaJSONResponse;
+import org.apache.sling.servlets.post.JakartaPostResponseCreator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,6 +44,11 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.servlet.http.HttpServletResponse;
+
 /**
  * Tests for the 'removeAce' Sling POST operation
  */
@@ -56,14 +56,14 @@ import org.osgi.framework.ServiceRegistration;
 @ExamReactorStrategy(PerClass.class)
 public class RemovePrincipalAcesIT extends PrincipalAceTestSupport {
 
-    private ServiceRegistration<PostResponseCreator> serviceReg;
+    private ServiceRegistration<JakartaPostResponseCreator> serviceReg;
 
     @Before
     @Override
     public void before() throws Exception {
         Bundle bundle = FrameworkUtil.getBundle(getClass());
         Dictionary<String, Object> props = new Hashtable<>(); // NOSONAR
-        serviceReg = bundle.getBundleContext().registerService(PostResponseCreator.class,
+        serviceReg = bundle.getBundleContext().registerService(JakartaPostResponseCreator.class,
                 new CustomPostResponseCreatorImpl(), props);
 
         super.before();
@@ -219,7 +219,7 @@ public class RemovePrincipalAcesIT extends PrincipalAceTestSupport {
         String postUrl = testFolderUrl + ".deletePAce.json";
 
         List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE));
+        postParams.add(new BasicNameValuePair(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE));
         postParams.add(new BasicNameValuePair(":applyTo", "pacetestuser"));
 
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
@@ -245,7 +245,7 @@ public class RemovePrincipalAcesIT extends PrincipalAceTestSupport {
         String postUrl = folderUrl + ".deletePAce.json";
 
         List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE));
+        postParams.add(new BasicNameValuePair(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE));
         postParams.add(new BasicNameValuePair(":applyTo", invalidUserId));
 
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
@@ -267,7 +267,7 @@ public class RemovePrincipalAcesIT extends PrincipalAceTestSupport {
         String postUrl = folderUrl + ".deletePAce.json";
 
         List<NameValuePair> postParams = new ArrayList<>();
-        postParams.add(new BasicNameValuePair(":http-equiv-accept", JSONResponse.RESPONSE_CONTENT_TYPE));
+        postParams.add(new BasicNameValuePair(":http-equiv-accept", JakartaJSONResponse.RESPONSE_CONTENT_TYPE));
         postParams.add(new BasicNameValuePair(":applyTo", "pacetestuser"));
 
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");

--- a/src/test/resources/exam.properties
+++ b/src/test/resources/exam.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Disable the default bundles provisioned under pax logging
+pax.exam.logging=none


### PR DESCRIPTION
bump bundle major version to 5.0.0
bump minimum java version to 17
bump slf4j-api to the 2.x version
bump dependencies to the latest that are compatible with sling api 3.x
migrate the javax.servlet references in non-pubic classes to jakarta.servlet
remove code that was deprecated before the last major release
break the circular integration test dependency on slingJcrJackrabbitUsermanager